### PR TITLE
feat: DSW-1246 add github actions workflow to build & deploy

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,0 +1,123 @@
+on:
+    workflow_call:
+      inputs:
+        amplify-app-id:
+          description: "The ID for your Amplify app (which you can get from the end of its ARN)"
+          required: true
+          type: string
+        package-name:
+          description: "Name of the application being deployed"
+          required: true
+          type: string
+        package-dist-directory:
+          description: "The directory where the package dist is located"
+          required: true
+          type: string
+        bucket-name-preview:
+          description: "Name of the preview bucket being deployed to"
+          required: false
+          type: string
+        bucket-name-main:
+          description: "Name of the main bucket being deployed to"
+          required: true
+          type: string
+
+env:
+  AMPLIFY_ID: ${{ inputs.amplify-app-id }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_REGION: 'eu-west-1'
+  BRANCH_NAME: ${{ github.event_name == 'pull_request' && format('pr{0}', github.event.number) || github.ref == 'refs/heads/main' && 'main' }}
+  BUCKET_NAME: ${{ github.event_name == 'pull_request' && inputs.bucket-name-preview || (github.ref == 'refs/heads/main' && inputs.bucket-name-main) }}
+  ZIP_NAME: ${{ github.event_name == 'pull_request' && format('{0}-{1}-preview.zip', inputs.package-name, github.event.number) || (github.ref == 'refs/heads/main' && format('{0}-main.zip', inputs.package-name)) }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the Repo
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Setup Node
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "yarn"
+
+      - name: Install Dependencies & Build - ${{ inputs.package-name }}
+        shell: bash
+        working-directory: ./${{ inputs.package-name }}
+        run: yarn && yarn build
+
+      # This is a slightly modified version of the following workflow - https://github.com/justeattakeaway/pie/blob/main/.github/workflows/amplify-deploy.yml
+      # Create Github Deployment
+      - name: Create Docs GitHub deployment
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: chrnorm/deployment-action@v2
+        id: deploy
+        with:
+            token: ${{ secrets.GITHUB_TOKEN }}
+            environment: "${{ inputs.package-name}}-pr-${{ github.event.number }}"
+
+      # Zip dist folder
+      - name: Zip build output
+        shell: bash
+        run: |
+            cd ${{ inputs.package-dist-directory }}
+            zip -r ./${{ env.ZIP_NAME }} .
+
+      # Upload zip to S3
+      - name: Upload to S3
+        id: upload-s3
+        uses: hkusu/s3-upload-action@v2
+        with:
+            aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+            aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+            aws-region: ${{ env.AWS_REGION }}
+            aws-bucket: ${{ env.BUCKET_NAME }}
+            bucket-root: "/"
+            destination-dir: "/"
+            file-path: "${{inputs.package-dist-directory}}/${{ env.ZIP_NAME }}"
+            content-type: "application/zip"
+            public: true
+
+      # Create branch on Amplify
+      - name: Create Amplify branch
+        shell: bash
+        # We return true to prevent the step from failing if the branch already exists
+        run: |
+            aws amplify create-branch \
+            --app-id ${{ inputs.amplify-app-id }} \
+            --branch-name ${{ env.BRANCH_NAME }} \
+            || true
+
+      # Deploy Amplify from S3
+      - name: Deploy Amplify from S3
+        shell: bash
+        run: |
+            aws amplify start-deployment \
+            --app-id ${{ inputs.amplify-app-id }} \
+            --branch-name ${{ env.BRANCH_NAME }} \
+            --source-url https://${{ env.BUCKET_NAME }}.s3.${{ env.AWS_REGION }}.amazonaws.com/${{ env.ZIP_NAME }}
+
+      # If successful
+      - name: Update deployment status (success)
+        if: ${{ github.event_name == 'pull_request' && success() }}
+        uses: chrnorm/deployment-status@v2
+        with:
+            token: ${{ secrets.GITHUB_TOKEN }}
+            environment-url: https://pr${{ github.event.number }}.${{ inputs.amplify-app-id }}.amplifyapp.com
+            deployment-id: ${{ steps.deploy.outputs.deployment_id }}
+            state: "success"
+
+      # If it failed
+      - name: Update deployment status (failure)
+        if: ${{ github.event_name == 'pull_request' && failure() }}
+        uses: chrnorm/deployment-status@v2
+        with:
+            token: ${{ secrets.GITHUB_TOKEN }}
+            environment-url: https://pr${{ github.event.number }}.${{ inputs.amplify-app-id }}.amplifyapp.com
+            deployment-id: ${{ steps.deploy.outputs.deployment_id }}
+            state: "failure"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build & Deploy
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build & Deploy
 
 on:
   pull_request:
@@ -19,26 +19,13 @@ concurrency:
 
 jobs:
 
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      # Checkout the Repo
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      # Setup Node
-      - name: Setup Node
-        uses: actions/setup-node@v3
+    build-deploy-vanilla-app:
+        name: Build & Deploy - vanilla-app
+        uses: ./.github/workflows/build-deploy.yml
         with:
-          node-version: 18
-          cache: "yarn"
-
-      - name: Install Dependencies & Build - Vanilla App
-        shell: bash
-        working-directory: ./vanilla-app
-        run: yarn && yarn build
-
-      - name: Install Dependencies & Build - Next App
-        shell: bash
-        working-directory: ./nextjs-app
-        run: yarn && yarn build
+            amplify-app-id: 'd2vb6sjgivffb3'
+            package-name: 'vanilla-app'
+            package-dist-directory: './vanilla-app/dist'
+            bucket-name-preview: 'pie-aperture-preview'
+            bucket-name-main: 'pie-aperture'
+        secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,14 @@ jobs:
             bucket-name-preview: 'pie-aperture-preview'
             bucket-name-main: 'pie-aperture'
         secrets: inherit
+
+    build-deploy-next-app:
+        name: Build & Deploy - nextjs-app
+        uses: ./.github/workflows/build-deploy.yml
+        with:
+            amplify-app-id: 'd1106vmj1ozg8d'
+            package-name: 'nextjs-app'
+            package-dist-directory: './nextjs-app/out'
+            bucket-name-preview: 'pie-aperture-preview'
+            bucket-name-main: 'pie-aperture'
+        secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build & Deploy
+name: Build
 
 on:
   pull_request:
@@ -42,16 +42,3 @@ jobs:
         shell: bash
         working-directory: ./nextjs-app
         run: yarn && yarn build
-
-#   deploy-vanilla-app:
-#     needs: build
-#     uses: ./.github/workflows/amplify-deploy.yml
-#     with:
-#       os: ubuntu-latest
-#       node-version: 18
-#       amplify-app-id: dvskdcoepjoyf
-#       package-name: 'pie-docs'
-#       package-dist-directory: ./apps/pie-docs/dist
-#       bucket-name-preview: 'pie-docs-preview'
-#       bucket-name-main: 'pie-docs'
-#     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: Build
+
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, "ready_for_review"]
+    paths-ignore:
+      - "**/README.md"
+      - "**/CONTRIBUTING.md"
+      - "**/CHANGELOG.md"
+      - "**/LICENSE"
+
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: CI-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the Repo
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Setup Node
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "yarn"
+
+      - name: Install Dependencies & Build - Vanilla App
+        shell: bash
+        working-directory: ./vanilla-app
+        run: yarn && yarn build
+
+      - name: Install Dependencies & Build - Next App
+        shell: bash
+        working-directory: ./nextjs-app
+        run: yarn && yarn build
+
+#   deploy-vanilla-app:
+#     needs: build
+#     uses: ./.github/workflows/amplify-deploy.yml
+#     with:
+#       os: ubuntu-latest
+#       node-version: 18
+#       amplify-app-id: dvskdcoepjoyf
+#       package-name: 'pie-docs'
+#       package-dist-directory: ./apps/pie-docs/dist
+#       bucket-name-preview: 'pie-docs-preview'
+#       bucket-name-main: 'pie-docs'
+#     secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,7 @@ next-env.d.ts
 
 # Next.js build output
 .next/
-/out/
+**/out/
 
 # Nuxt.js build / generate output
 .nuxt
@@ -175,3 +175,5 @@ lit-visual-report/
 compiled/
 
 **/src/react.ts
+
+

--- a/nextjs-app/next.config.js
+++ b/nextjs-app/next.config.js
@@ -4,6 +4,11 @@ const withLitSSR = require('@lit-labs/nextjs')();
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  // This makes nextjs build via SSG as this is currently the simplist way to deploy to AWS Amplify.
+  output: 'export',
+  images: {
+    unoptimized: true
+  }
 }
 
 module.exports = withLitSSR(nextConfig);

--- a/nextjs-app/src/components/layout.tsx
+++ b/nextjs-app/src/components/layout.tsx
@@ -2,7 +2,7 @@ import Head from 'next/head'
 import { Inter } from 'next/font/google'
 
 const inter = Inter({ subsets: ['latin'] })
-
+// @ts-ignore
 export default function Layout({ children }) {
   return (
     <>

--- a/vanilla-app/package.json
+++ b/vanilla-app/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build:examples": "vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR adds the following functionality:

- Add Github Actions workflow to build / deploy the apps to AWS. As noted, a bulk of the logic is copied from PIE for simplicity's sake, but we can look to remove duplication in the future if we wish.

- Updated .gitignore to ignore the `out` directory produced when building the Next app.
- Modified the Next config to only build via SSG, as this is currently the easiest way to deploy to AWS. We can look at SSR in the future.
- Added a `@ts-ignore` to prevent the Next build from failing due to TS type error.