### PR TITLE
Click propagation bug reproduction

### DIFF
--- a/vanilla-app/main.js
+++ b/vanilla-app/main.js
@@ -25,6 +25,18 @@ document.querySelector('#app').innerHTML = `
         headingLevel="h3"
         leadingAction='${JSON.stringify({ text: 'Leading action' })}'
         isDismissible>
+        <pie-button type="button" onclick="document.querySelector('ul').innerHTML = ''">
+            Remove list
+        </pie-button>
+        <ul>
+            <li></li>
+            <li></li>
+            <li></li>
+            <li></li>
+            <li></li>
+            <li></li>
+            <li></li>
+        </ul>
         Modal content
     </pie-modal>
 
@@ -69,14 +81,14 @@ document.querySelector('#app').innerHTML = `
 
     <h2>pie-spinner</h2>
     <pie-spinner></pie-spinner>
-    
+
     <pie-divider></pie-divider>
-    
+
     <h2>pie-form-label</h2>
     <pie-form-label>Label</pie-form-label>
-    
+
     <pie-divider></pie-divider>
-    
+
     <h2>pie-tag</h2>
     <pie-tag>Pie Tag</pie-tag>
 `;


### PR DESCRIPTION
### Steps to reproduce:
1. Go to https://pr50-aperture-vanilla-app.pie.design/
2. Click on the "open modal" button. The modal should appear.
3. Click on the **bottom part** of the "Remove list" button (below the text). The list should be removed and the modal should remain open.
4. Refresh the page.
5. Click on the "open modal". The modal should appear and the list should be present again.
6. Click on the **top part** of the "Remove list" button (above the text). The modal closes. (If you then click "open modal" again you will see that the list was removed at the same time.)

> [!NOTE]
> These reproduction steps have been tailored for a desktop viewport, they may not apply exactly the same for narrower viewports.

This seems to be happening because the modal resizes as a result of the click. When you click on the lower edge of the button, the mouse is still over the modal after the resize. If you click the upper edge of the button, the mouse is no longer above the modal once the click event resolves, therefore it is also registered as a click outside the modal, which triggers the "light dismiss" behaviour.

This issue is resolved if the consumer adds click propagation, but this feels like something we should fix so that they don't run into this bug in the first place.