### PR TITLE
chore: DSW-1636 add amplify config

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,36 @@
+version: 1
+applications:
+  - appRoot: nuxt-app
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - yarn install
+        build:
+          commands:
+            - yarn build
+      artifacts:
+        baseDirectory: .amplify-hosting
+        files:
+          - '**/*'
+      cache:
+        paths:
+          - node_modules/**/*
+
+  - appRoot: nextjs-app
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - yarn install
+        build:
+          commands:
+            - yarn build
+      artifacts:
+        baseDirectory: .next
+        files:
+          - '**/*'
+      cache:
+        paths:
+          - node_modules/**/*
+        


### PR DESCRIPTION
This PR adds the initial config file for amplify deployments. It won't be in use yet on `main`, but I've tested in another branch and it works as expected.

The purpose of integrating this file in isolation, is to better test integration with the Amplify GitHub app for automatic branch creation / deletion / previews, as we'll be moving away from our custom implementation.