### PR TITLE
feat: DSW-1589 add pie-input to example applications

### DIFF
--- a/nextjs-app/package.json
+++ b/nextjs-app/package.json
@@ -21,6 +21,7 @@
     "@justeattakeaway/pie-form-label": "0.11.0",
     "@justeattakeaway/pie-icon-button": "0.27.2",
     "@justeattakeaway/pie-icons-webc": "0.17.2",
+    "@justeattakeaway/pie-input": "0.10.0",
     "@justeattakeaway/pie-link": "0.15.0",
     "@justeattakeaway/pie-modal": "0.38.4",
     "@justeattakeaway/pie-spinner": "0.5.2",

--- a/nextjs-app/src/pages/form.tsx
+++ b/nextjs-app/src/pages/form.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { PieSwitch } from '@justeattakeaway/pie-switch/dist/react';
 import { PieButton } from '@justeattakeaway/pie-button/dist/react';
+import { PieInput } from '@justeattakeaway/pie-input/dist/react';
 
 export default function Form() {
     const [approveSettings, setApproveSettings] = useState(false);
@@ -12,9 +13,9 @@ export default function Form() {
     const [password, setPassword] = useState('');
     const [passwordConfirmation, setPasswordConfirmation] = useState('');
 
-    const handleUsernameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        setUsername(event.target.value);   
-    };
+    const handleUsernameInput = (event: InputEvent) => {
+        setUsername((event.target as HTMLInputElement).value);
+    }
 
     const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         setEmail(event.target.value);   
@@ -57,14 +58,14 @@ export default function Form() {
                 <label htmlFor="username">
                     Username:
                 </label>
-                <input
+                <PieInput
                     className="form-field"
                     id="username"
                     data-test-id="username"
                     name="username"
                     value={username}
-                    onChange={handleUsernameChange}
-                    type="text" />
+                    onInput={handleUsernameInput as any}
+                    type="text"></PieInput>
 
                 <label htmlFor="email">
                     Email:

--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@justeattakeaway/pie-button": "^0.45.2",
     "@justeattakeaway/pie-css": "^0.10.0",
+    "@justeattakeaway/pie-input": "0.10.0",
     "@justeattakeaway/pie-switch": "^0.26.0",
     "lit": "^3.1.1",
     "nuxt-ssr-lit": "^1.6.10"

--- a/nuxt-app/pages/form.vue
+++ b/nuxt-app/pages/form.vue
@@ -5,13 +5,14 @@
             <label for="username">
                 Username:
             </label>
-            <input
+            <pie-input
+                :value="username"
+                @input="handleUsernameInput"
                 class="form-field"
                 id="username"
                 data-test-id="username"
                 name="username"
-                v-model="username"
-                type="text" />
+                type="text"></pie-input>
         
             <label for="email">
                 Email:
@@ -76,16 +77,16 @@
     </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { PieButton } from '@justeattakeaway/pie-button';
 import { PieSwitch } from '@justeattakeaway/pie-switch';
-
+import { PieInput } from '@justeattakeaway/pie-input';
 import { defineModel } from 'vue';
 
-const username = defineModel('username');
-const email = defineModel('email');
-const password = defineModel('password');
-const passwordConfirmation = defineModel('passwordConfirmation');
+const username = defineModel('username', { default: '' });
+const email = defineModel('email', { default: '' });
+const password = defineModel('password', { default: '' });
+const passwordConfirmation = defineModel('passwordConfirmation', { default: '' });
 const approveSettings = defineModel('approveSettings', { default: false });
 const notifications = defineModel('notifications', { default: false });
 
@@ -101,6 +102,10 @@ function handleSubmit(event) {
         approveSettings: approveSettings.value,
         enableNotifications: notifications.value
     }, null, 2);
+}
+
+function handleUsernameInput(event) {
+    username.value = event.target.value;
 }
 
 function handleNotificationsChange(event) {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "turbo run lint --token=${TURBO_TOKEN}",
     "test:system": "turbo run test:system --token=${TURBO_TOKEN} --continue",
     "playwright:show-report": "turbo run playwright:show-report",
+    "preview": "turbo run preview",
     "test:visual": "turbo run test:visual",
     "upgrade-pie-packages": "turbo run upgrade-pie-packages && yarn"
   },

--- a/test/playwright/page-objects/form.page.ts
+++ b/test/playwright/page-objects/form.page.ts
@@ -32,7 +32,7 @@ export class FormPage {
     }
 
     async fillForm(formData: any) {
-        await this.usernameField.fill(formData.username);
+        await this.usernameField.locator('input').fill(formData.username);
         await this.emailField.fill(formData.email);
         await this.passwordField.fill(formData.password);
         await this.passwordConfirmationField.fill(formData.passwordConfirmation);

--- a/vanilla-app/form.html
+++ b/vanilla-app/form.html
@@ -32,14 +32,14 @@
         <form class="form" id="testForm">
             <label for="username">
                 Username:
-            </label>
-            <input
+            </label>            
+            <pie-input
                 class="form-field"
                 id="username"
                 data-test-id="username"
                 name="username"
-                type="text" />
-        
+                type="text">
+            </pie-input>
             <label for="email">
                 Email:
             </label>

--- a/vanilla-app/form.html
+++ b/vanilla-app/form.html
@@ -32,7 +32,7 @@
         <form class="form" id="testForm">
             <label for="username">
                 Username:
-            </label>            
+            </label>
             <pie-input
                 class="form-field"
                 id="username"

--- a/vanilla-app/form.js
+++ b/vanilla-app/form.js
@@ -1,5 +1,6 @@
 import '@justeattakeaway/pie-css';
 import '@justeattakeaway/pie-button';
+import '@justeattakeaway/pie-input';
 import '@justeattakeaway/pie-switch';
 import '@justeattakeaway/pie-divider';
 import './style.css';

--- a/vanilla-app/package.json
+++ b/vanilla-app/package.json
@@ -25,6 +25,7 @@
     "@justeattakeaway/pie-form-label": "0.11.0",
     "@justeattakeaway/pie-icon-button": "0.27.2",
     "@justeattakeaway/pie-icons-webc": "0.17.2",
+    "@justeattakeaway/pie-input": "0.10.0",
     "@justeattakeaway/pie-link": "0.15.0",
     "@justeattakeaway/pie-modal": "0.38.4",
     "@justeattakeaway/pie-spinner": "0.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1237,6 +1237,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@justeattakeaway/pie-input@npm:0.10.0":
+  version: 0.10.0
+  resolution: "@justeattakeaway/pie-input@npm:0.10.0"
+  dependencies:
+    "@justeattakeaway/pie-webc-core": 0.17.1
+  checksum: 992dec03724fa220e49a42bdc765fed152829a2bf126409c04be66d5b7167d96b3c298314efa88585720d5f412b14146eaa1aea37aaa75ca1d492636eb244e22
+  languageName: node
+  linkType: hard
+
 "@justeattakeaway/pie-link@npm:0.15.0":
   version: 0.15.0
   resolution: "@justeattakeaway/pie-link@npm:0.15.0"
@@ -9923,6 +9932,7 @@ __metadata:
     "@justeattakeaway/pie-form-label": 0.11.0
     "@justeattakeaway/pie-icon-button": 0.27.2
     "@justeattakeaway/pie-icons-webc": 0.17.2
+    "@justeattakeaway/pie-input": 0.10.0
     "@justeattakeaway/pie-link": 0.15.0
     "@justeattakeaway/pie-modal": 0.38.4
     "@justeattakeaway/pie-spinner": 0.5.2
@@ -10332,6 +10342,7 @@ __metadata:
   dependencies:
     "@justeattakeaway/pie-button": ^0.45.2
     "@justeattakeaway/pie-css": ^0.10.0
+    "@justeattakeaway/pie-input": 0.10.0
     "@justeattakeaway/pie-switch": ^0.26.0
     deepmerge: 4.3.1
     lit: ^3.1.1
@@ -13969,6 +13980,7 @@ __metadata:
     "@justeattakeaway/pie-form-label": 0.11.0
     "@justeattakeaway/pie-icon-button": 0.27.2
     "@justeattakeaway/pie-icons-webc": 0.17.2
+    "@justeattakeaway/pie-input": 0.10.0
     "@justeattakeaway/pie-link": 0.15.0
     "@justeattakeaway/pie-modal": 0.38.4
     "@justeattakeaway/pie-spinner": 0.5.2


### PR DESCRIPTION
This PR adds `pie-input` to all example applications.

Currently, only type 'text' is available for this component, hence why only the username field has been updated in the form page.