### PR TITLE
ci(pie-aperture): DSW-0 print list of published snapshots

### DIFF
--- a/.github/workflows/pie-trigger.yml
+++ b/.github/workflows/pie-trigger.yml
@@ -1,0 +1,13 @@
+name: PIE Trigger
+
+on:
+  repository_dispatch:
+    types: [pie-trigger]
+    
+jobs:
+  list-snapshots:
+    runs-on: ubuntu-latest
+    steps:
+        - name: Return list of created snapshots
+          run: |
+            echo "Created Snapshots: ${{ github.event.client_payload.snapshots}}"

--- a/.github/workflows/pie-trigger.yml
+++ b/.github/workflows/pie-trigger.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
         - name: Return list of created snapshots
           run: |
-            echo "Created Snapshots: ${{ github.event.client_payload.snapshots}}"
+            echo "Created Snapshots: ${{ github.event.client_payload.snapshots }}"


### PR DESCRIPTION
This is a demo workflow to test the `/test-aperture` trigger from PIE.

In its current state, this workflow will list list of published snapshots that were passed to PIE Aperture as part of the event payload.

