### PR TITLE
ci: DSW-2037 updated nextjs CI workflow to nextjs-13 naming convention

### DIFF
--- a/.github/workflows/ci-nextjs-v13.yml
+++ b/.github/workflows/ci-nextjs-v13.yml
@@ -1,4 +1,4 @@
-name: Build - NextJS App
+name: Build - NextJS 13 App
 
 on:
   pull_request:
@@ -14,7 +14,7 @@ on:
       - main
 
 concurrency:
-  group: CI-NextJS-${{ github.ref }}
+  group: CI-NextJS-13-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
@@ -108,6 +108,6 @@ jobs:
     env:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-      NEXT_AMPLIFY_ID: d1106vmj1ozg8d
+      NEXT_13_AMPLIFY_ID: d1106vmj1ozg8d
       PERCY_TOKEN_PIE_APERTURE_NEXT_13: ${{ secrets.PERCY_TOKEN_PIE_APERTURE_NEXT_13 }}
       PR_NUMBER: ${{ github.event.number }}

--- a/playwright-helpers/configuration-helper.js
+++ b/playwright-helpers/configuration-helper.js
@@ -1,4 +1,4 @@
-const { CI, GITHUB_REF_NAME, PR_NUMBER, VANILLA_AMPLIFY_ID, NEXT_AMPLIFY_ID, NEXT_14_AMPLIFY_ID, NUXT_AMPLIFY_ID } = process.env;
+const { CI, GITHUB_REF_NAME, PR_NUMBER, VANILLA_AMPLIFY_ID, NEXT_13_AMPLIFY_ID, NEXT_14_AMPLIFY_ID, NUXT_AMPLIFY_ID } = process.env;
 
 export function getAppConfig(appName) {
     const config = {};
@@ -9,7 +9,7 @@ export function getAppConfig(appName) {
             config.port = '3001';
             break;
         case 'nextjs-app-v13':
-            config.amplifyId = NEXT_AMPLIFY_ID;
+            config.amplifyId = NEXT_13_AMPLIFY_ID;
             config.port = '3000';
             break;
         case 'nextjs-app-v14':

--- a/webdriver-helpers/configuration-helper.js
+++ b/webdriver-helpers/configuration-helper.js
@@ -1,4 +1,4 @@
-const { CI, GITHUB_REF_NAME, GITHUB_RUN_ID, PR_NUMBER, VANILLA_AMPLIFY_ID, NEXT_AMPLIFY_ID, NEXT_14_AMPLIFY_ID, NUXT_AMPLIFY_ID } = process.env;
+const { CI, GITHUB_REF_NAME, GITHUB_RUN_ID, PR_NUMBER, VANILLA_AMPLIFY_ID, NEXT_13_AMPLIFY_ID, NEXT_14_AMPLIFY_ID, NUXT_AMPLIFY_ID } = process.env;
 const { execSync } = require('child_process');
 
 exports.getAppConfig = (appName) => {
@@ -10,7 +10,7 @@ exports.getAppConfig = (appName) => {
             config.port = '3001';
             break;
         case 'nextjs-app-v13':
-            config.amplifyId = NEXT_AMPLIFY_ID;
+            config.amplifyId = NEXT_13_AMPLIFY_ID;
             config.port = '3000';
             break;
         case 'nextjs-app-v14':


### PR DESCRIPTION
- Updated nextjs ci GIthub Actions workflow naming and all related naming to follow the same naming convention as NextJS 14 workflow.

The Amplify instance will also be renamed to follow the same naming convention.