### PR TITLE
DSW-000: Follow redirects in SSR tests

### DIFF
--- a/.github/workflows/ci-nextjs-v13.yml
+++ b/.github/workflows/ci-nextjs-v13.yml
@@ -8,6 +8,8 @@ on:
       - 'nextjs-app-v13/**'
       - 'webdriver-helpers/**'
       - 'wdio.conf.js'
+      - 'test/**'
+      - 'playwright-helpers/**'
 
   push:
     branches:

--- a/.github/workflows/ci-nextjs-v14.yml
+++ b/.github/workflows/ci-nextjs-v14.yml
@@ -8,6 +8,8 @@ on:
       - 'nextjs-app-v14/**'
       - 'webdriver-helpers/**'
       - 'wdio.conf.js'
+      - 'test/**'
+      - 'playwright-helpers/**'
 
   push:
     branches:

--- a/.github/workflows/ci-nuxtjs.yml
+++ b/.github/workflows/ci-nuxtjs.yml
@@ -8,6 +8,8 @@ on:
       - 'nuxt-app/**'
       - 'webdriver-helpers/**'
       - 'wdio.conf.js'
+      - 'test/**'
+      - 'playwright-helpers/**'
 
   push:
     branches:

--- a/.github/workflows/ci-vanilla.yml
+++ b/.github/workflows/ci-vanilla.yml
@@ -8,6 +8,8 @@ on:
       - 'vanilla-app/**'
       - 'webdriver-helpers/**'
       - 'wdio.conf.js'
+      - 'test/**'
+      - 'playwright-helpers/**'
   push:
     branches:
       - main

--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,5 @@ compiled/
 
 # Playwright
 **/playwright-reports/*-playwright-report
+
+test-results

--- a/nuxt-app/nuxt.config.ts
+++ b/nuxt-app/nuxt.config.ts
@@ -2,12 +2,6 @@
 export default defineNuxtConfig({
   ssr: true,
 
-  router: {
-    options: {
-        strict: false,
-    },
-  },
-
   nitro: {
       moduleSideEffects: [
           '@justeattakeaway/pie-icons-webc',

--- a/nuxt-app/nuxt.config.ts
+++ b/nuxt-app/nuxt.config.ts
@@ -2,6 +2,12 @@
 export default defineNuxtConfig({
   ssr: true,
 
+  router: {
+    options: {
+        strict: false,
+    },
+  },
+
   nitro: {
       moduleSideEffects: [
           '@justeattakeaway/pie-icons-webc',

--- a/nuxt-app/pages/components/icon-button.vue
+++ b/nuxt-app/pages/components/icon-button.vue
@@ -9,7 +9,7 @@
 <script setup lang="ts">
 import { definePageMeta } from '#imports';
 import '@justeattakeaway/pie-webc/components/icon-button.js';
-import { IconClose } from '@justeattakeaway/pie-icons-webc';
+import '@justeattakeaway/pie-icons-webc/dist/IconClose.js';
 
 definePageMeta({
     title: 'PIE Icon Button',

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@percy/cli": "1.28.0",
     "@percy/selenium-webdriver": "2.0.2",
     "@playwright/test": "1.41.1",
+    "@types/follow-redirects": "^1.14.4",
     "@types/node": "20.11.13",
     "@wdio/browserstack-service": "8.24.1",
     "@wdio/cli": "8.19.0",
@@ -41,6 +42,7 @@
     "@wdio/mocha-framework": "8.19.0",
     "@wdio/spec-reporter": "8.19.0",
     "cross-env": "7.0.3",
+    "follow-redirects": "1.15.6",
     "playwright-merge-html-reports": "0.2.8",
     "selenium-webdriver": "4.14.0",
     "turbo": "1.12.2"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@percy/cli": "1.28.0",
     "@percy/selenium-webdriver": "2.0.2",
     "@playwright/test": "1.41.1",
-    "@types/follow-redirects": "^1.14.4",
+    "@types/follow-redirects": "1.14.4",
     "@types/node": "20.11.13",
     "@wdio/browserstack-service": "8.24.1",
     "@wdio/cli": "8.19.0",

--- a/test/ssr/ssr.spec.ts
+++ b/test/ssr/ssr.spec.ts
@@ -39,8 +39,8 @@ async function fetchHtml(url: string): Promise<string> {
         protocol.get(url, (response) => {
             let data = '';
 
-            console.log('Getting', url);
-            console.log('Status:', response.statusCode);
+            console.info('Getting', url);
+            console.info('Status:', response.statusCode);
 
             response.on('data', (chunk) => {
                 data += chunk;

--- a/test/ssr/ssr.spec.ts
+++ b/test/ssr/ssr.spec.ts
@@ -30,7 +30,7 @@ const components = [
     'textarea',
 ];
 
-const getComponentPageUrl = (component: string, baseUrl: string): string => `${baseUrl}/components/${component}`;
+const getComponentPageUrl = (component: string, baseUrl: string): string => `${baseUrl}/components/${component}/`;
 
 async function fetchHtml(url: string): Promise<string> {
     return new Promise<string>((resolve, reject) => {
@@ -39,6 +39,8 @@ async function fetchHtml(url: string): Promise<string> {
 
         protocol.get(url, (response) => {
             let data = '';
+
+            console.log('Status:', response.statusCode);
 
             response.on('data', (chunk) => {
                 data += chunk;

--- a/test/ssr/ssr.spec.ts
+++ b/test/ssr/ssr.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '@playwright/test';
-import http from 'http';
-import https from 'https';
+import { http, https } from 'follow-redirects';
 import { URL } from 'url';
 import { getEnvironmentBaseUrl } from '../../playwright-helpers/configuration-helper';
 

--- a/test/ssr/ssr.spec.ts
+++ b/test/ssr/ssr.spec.ts
@@ -30,7 +30,7 @@ const components = [
     'textarea',
 ];
 
-const getComponentPageUrl = (component: string, baseUrl: string): string => `${baseUrl}/components/${component}/`;
+const getComponentPageUrl = (component: string, baseUrl: string): string => `${baseUrl}/components/${component}`;
 
 async function fetchHtml(url: string): Promise<string> {
     return new Promise<string>((resolve, reject) => {

--- a/test/ssr/ssr.spec.ts
+++ b/test/ssr/ssr.spec.ts
@@ -30,7 +30,7 @@ const components = [
     'textarea',
 ];
 
-const getComponentPageUrl = (component: string, baseUrl: string): string => `${baseUrl}/components/${component}`;
+const getComponentPageUrl = (component: string, baseUrl: string): string => `${baseUrl}/components/${component}/`;
 
 async function fetchHtml(url: string): Promise<string> {
     return new Promise<string>((resolve, reject) => {

--- a/test/ssr/ssr.spec.ts
+++ b/test/ssr/ssr.spec.ts
@@ -85,9 +85,9 @@ test.describe('SSR - Components render with shadow dom and styles', () => {
             const pieComponentMatch = rawHtml.match(componentRegex);
 
             if (!pieComponentMatch) {
-                console.warn('Get component page baseURL output: ', baseUrl)
-                console.warn('Get component page URL output: ', url)
-                console.warn('Failed to find component in the SSR html: ', rawHtml)
+                console.warn('Get component page baseURL output:', baseUrl);
+                console.warn('Get component page URL output:', url);
+                console.warn('Failed to find component in the SSR html:', rawHtml);
             }
 
             const pieComponentHtml = pieComponentMatch ? pieComponentMatch[0] : null;

--- a/test/ssr/ssr.spec.ts
+++ b/test/ssr/ssr.spec.ts
@@ -40,6 +40,7 @@ async function fetchHtml(url: string): Promise<string> {
         protocol.get(url, (response) => {
             let data = '';
 
+            console.log('Getting', url);
             console.log('Status:', response.statusCode);
 
             response.on('data', (chunk) => {

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,7 @@
         "dependsOn": ["build"]
       },
       "test:ssr": {
-        "cache": true
+        "cache": false
       },
       "test:system": {
         "cache": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -3587,7 +3587,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/follow-redirects@npm:^1.14.4":
+"@types/follow-redirects@npm:1.14.4":
   version: 1.14.4
   resolution: "@types/follow-redirects@npm:1.14.4"
   dependencies:
@@ -12523,7 +12523,7 @@ __metadata:
     "@percy/cli": 1.28.0
     "@percy/selenium-webdriver": 2.0.2
     "@playwright/test": 1.41.1
-    "@types/follow-redirects": ^1.14.4
+    "@types/follow-redirects": 1.14.4
     "@types/node": 20.11.13
     "@wdio/browserstack-service": 8.24.1
     "@wdio/cli": 8.19.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3587,6 +3587,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/follow-redirects@npm:^1.14.4":
+  version: 1.14.4
+  resolution: "@types/follow-redirects@npm:1.14.4"
+  dependencies:
+    "@types/node": "*"
+  checksum: 8d5e4a7efa3602d26a2e0a2ff8970d29ba900c13874b29038faebc69adc89b0c78b34cd1100fac638c686848a52916c0310fb27c6e5300c0e19830e7f4f63094
+  languageName: node
+  linkType: hard
+
 "@types/gitconfiglocal@npm:^2.0.1":
   version: 2.0.3
   resolution: "@types/gitconfiglocal@npm:2.0.3"
@@ -8434,6 +8443,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"follow-redirects@npm:1.15.6":
+  version: 1.15.6
+  resolution: "follow-redirects@npm:1.15.6"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: a62c378dfc8c00f60b9c80cab158ba54e99ba0239a5dd7c81245e5a5b39d10f0c35e249c3379eae719ff0285fff88c365dd446fab19dee771f1d76252df1bbf5
+  languageName: node
+  linkType: hard
+
 "for-each@npm:^0.3.3":
   version: 0.3.3
   resolution: "for-each@npm:0.3.3"
@@ -12504,6 +12523,7 @@ __metadata:
     "@percy/cli": 1.28.0
     "@percy/selenium-webdriver": 2.0.2
     "@playwright/test": 1.41.1
+    "@types/follow-redirects": ^1.14.4
     "@types/node": 20.11.13
     "@wdio/browserstack-service": 8.24.1
     "@wdio/cli": 8.19.0
@@ -12513,6 +12533,7 @@ __metadata:
     commitizen: 4.3.0
     cross-env: 7.0.3
     cz-customizable: 7.0.0
+    follow-redirects: 1.15.6
     playwright-merge-html-reports: 0.2.8
     selenium-webdriver: 4.14.0
     turbo: 1.12.2


### PR DESCRIPTION
- Follow redirects during SSR tests to make sure the HTML is fetched properly
- Run CI for all apps when tests change
- Fix icon import on Nuxt icon-button page

| Following redirects | Without following redirects |
| --- | --- |
| 200 OK response | Initial response is 301. Redirecting to add the `/`. The 301 has no response body therefore no HTML containing the component. |
| ![2024-08-06 12_04_00](https://github.com/user-attachments/assets/361e144a-5478-4caf-a07e-8f3fcc1df6c2) | ![2024-08-06 12_09_06](https://github.com/user-attachments/assets/23fe8f86-6c3d-431b-8a30-d39511e025c4) |