### PR TITLE
DSW-2302: Use latest pie component versions

### DIFF
--- a/nextjs-app-v13/package.json
+++ b/nextjs-app-v13/package.json
@@ -13,10 +13,10 @@
     "upgrade-pie-packages": "npx npm-check-updates \"@justeattakeaway/pie-*\" -u"
   },
   "dependencies": {
-    "@justeattakeaway/pie-cookie-banner": "0.24.0",
+    "@justeattakeaway/pie-cookie-banner": "0.25.0",
     "@justeattakeaway/pie-css": "0.12.1",
     "@justeattakeaway/pie-icons-webc": "0.25.0",
-    "@justeattakeaway/pie-webc": "0.5.19",
+    "@justeattakeaway/pie-webc": "0.5.25",
     "@lit-labs/nextjs": "0.1.4",
     "@lit/react": "1.0.2",
     "next": "13.5.6",

--- a/nextjs-app-v14/package.json
+++ b/nextjs-app-v14/package.json
@@ -14,10 +14,10 @@
     "upgrade-pie-packages": "npx npm-check-updates \"@justeattakeaway/pie-*\" -u"
   },
   "dependencies": {
-    "@justeattakeaway/pie-cookie-banner": "0.24.0",
+    "@justeattakeaway/pie-cookie-banner": "0.25.0",
     "@justeattakeaway/pie-css": "0.12.1",
     "@justeattakeaway/pie-icons-webc": "0.25.0",
-    "@justeattakeaway/pie-webc": "0.5.19",
+    "@justeattakeaway/pie-webc": "0.5.25",
     "@lit-labs/nextjs": "0.2.0",
     "@lit/react": "1.0.5",
     "next": "14.2.3",

--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -21,10 +21,10 @@
     "vue-router": "4.3.2"
   },
   "dependencies": {
-    "@justeattakeaway/pie-cookie-banner": "0.24.0",
+    "@justeattakeaway/pie-cookie-banner": "0.25.0",
     "@justeattakeaway/pie-css": "0.12.1",
     "@justeattakeaway/pie-icons-webc": "0.25.0",
-    "@justeattakeaway/pie-webc": "0.5.19",
+    "@justeattakeaway/pie-webc": "0.5.25",
     "just-kebab-case": "4.2.0",
     "nuxt-ssr-lit": "1.6.16"
   },

--- a/vanilla-app/package.json
+++ b/vanilla-app/package.json
@@ -18,10 +18,10 @@
     "vite-plugin-html-inject": "1.1.2"
   },
   "dependencies": {
-    "@justeattakeaway/pie-cookie-banner": "0.24.0",
+    "@justeattakeaway/pie-cookie-banner": "0.25.0",
     "@justeattakeaway/pie-css": "0.12.1",
     "@justeattakeaway/pie-icons-webc": "0.25.0",
-    "@justeattakeaway/pie-webc": "0.5.19"
+    "@justeattakeaway/pie-webc": "0.5.25"
   },
   "installConfig": {
     "hoistingLimits": "workspaces"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1537,13 +1537,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-assistive-text@npm:0.6.1":
-  version: 0.6.1
-  resolution: "@justeattakeaway/pie-assistive-text@npm:0.6.1"
+"@justeattakeaway/pie-assistive-text@npm:0.7.0":
+  version: 0.7.0
+  resolution: "@justeattakeaway/pie-assistive-text@npm:0.7.0"
   dependencies:
     "@justeattakeaway/pie-icons-webc": 0.25.0
     "@justeattakeaway/pie-webc-core": 0.24.0
-  checksum: 469820268075b909c31a655d304aa2e9086bdbd9ea2541a436707a71ab341c7be8d7e792913da639c2f607edc8994fa2c44882f9a978724a7f7282717bfda26b
+  checksum: 302ea0150ac8277d9b4f0727cba9c09765eee859c819e675ecb7818f3342b71a65e8420bb36c679ff80b2ec229e0b649632609fccdced81d0657117c64a4f76e
   languageName: node
   linkType: hard
 
@@ -1567,49 +1567,64 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-checkbox-group@npm:0.6.0":
-  version: 0.6.0
-  resolution: "@justeattakeaway/pie-checkbox-group@npm:0.6.0"
+"@justeattakeaway/pie-checkbox-group@npm:0.6.2":
+  version: 0.6.2
+  resolution: "@justeattakeaway/pie-checkbox-group@npm:0.6.2"
   dependencies:
-    "@justeattakeaway/pie-assistive-text": 0.6.1
+    "@justeattakeaway/pie-assistive-text": 0.7.0
     "@justeattakeaway/pie-webc-core": 0.24.0
-  checksum: 7e25b430920d5e28cec037815e52e7e2b926041e365867774868504169ff3d072b477cca29fbbbc1108d3d86a32445d28dbceedb2ecaeb0add1ded15ff8e5d29
+  checksum: b5132c11bf6de6a849847994b0ddb886320ba93cd7e3b2bee87b96a57c74972c5406298fd8083fbe179e7c149b284b95251f92df84736ba20871b075588b821a
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-checkbox@npm:0.12.0":
-  version: 0.12.0
-  resolution: "@justeattakeaway/pie-checkbox@npm:0.12.0"
+"@justeattakeaway/pie-checkbox@npm:0.12.2":
+  version: 0.12.2
+  resolution: "@justeattakeaway/pie-checkbox@npm:0.12.2"
   dependencies:
-    "@justeattakeaway/pie-assistive-text": 0.6.1
+    "@justeattakeaway/pie-assistive-text": 0.7.0
     "@justeattakeaway/pie-webc-core": 0.24.0
-  checksum: 7af6da888e2fd026f8fa2431b1d8f60d3bfbdf1533d0642a7ba00729145067844882af9f99f002ccaae53962808f2896eb97f40e1de13a94479748688c98a0fc
+  checksum: 1db7b5072b15ba0724676cd19765023f812fbaa76bb3b2ee89481c1c4b5ab50e9cc88bd162aa84eec705ea29d81b1409d7ec8d4aae949fba87e5e77be1b8e7b6
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-chip@npm:0.7.2":
-  version: 0.7.2
-  resolution: "@justeattakeaway/pie-chip@npm:0.7.2"
+"@justeattakeaway/pie-chip@npm:0.8.0":
+  version: 0.8.0
+  resolution: "@justeattakeaway/pie-chip@npm:0.8.0"
   dependencies:
     "@justeattakeaway/pie-icons-webc": 0.25.0
     "@justeattakeaway/pie-spinner": 0.6.7
     "@justeattakeaway/pie-webc-core": 0.24.0
-  checksum: 1af89ca83ba6ca733901d3e88fe44686ba349e3c8d665bb627716425ebd39d8819cfb9a1cdd4010caced92169c819678c94271dad9359d8b445cd1885b702a5d
+  checksum: 8022c278566ed001d7e0f86c7eceef17c733d2f20bbbfb30cdb7741c5be467c880007f152f1a3d59617d16f0dfb883a69c187deffdc21f77e2a7f346f990c024
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-cookie-banner@npm:0.24.0":
-  version: 0.24.0
-  resolution: "@justeattakeaway/pie-cookie-banner@npm:0.24.0"
+"@justeattakeaway/pie-cookie-banner@npm:0.25.0":
+  version: 0.25.0
+  resolution: "@justeattakeaway/pie-cookie-banner@npm:0.25.0"
   dependencies:
     "@justeattakeaway/pie-button": 0.48.1
-    "@justeattakeaway/pie-divider": 0.13.8
+    "@justeattakeaway/pie-divider": 0.13.9
     "@justeattakeaway/pie-icon-button": 0.28.10
     "@justeattakeaway/pie-link": 0.17.8
-    "@justeattakeaway/pie-modal": 0.45.0
+    "@justeattakeaway/pie-modal": 0.46.0
     "@justeattakeaway/pie-switch": 0.29.12
     "@justeattakeaway/pie-webc-core": 0.24.0
-  checksum: 53cb995cf028e9f91b30dbe3b71125e1462174dd5d8ddb0f4000f20446271bd27f4b143d5f8bb675a3022320f220539f05ad00a911390bd14ba3229d7590749b
+  checksum: 58ff5466a1a9d176f6426633535e4e28f0de169dfcc864832c3532102078a06a6ab958d779ea234f203ef6c6169cb580f33df880ca8c0a75a1aa43489bceea33
+  languageName: node
+  linkType: hard
+
+"@justeattakeaway/pie-cookie-banner@npm:0.25.1":
+  version: 0.25.1
+  resolution: "@justeattakeaway/pie-cookie-banner@npm:0.25.1"
+  dependencies:
+    "@justeattakeaway/pie-button": 0.48.1
+    "@justeattakeaway/pie-divider": 0.13.9
+    "@justeattakeaway/pie-icon-button": 0.28.10
+    "@justeattakeaway/pie-link": 0.17.8
+    "@justeattakeaway/pie-modal": 0.46.0
+    "@justeattakeaway/pie-switch": 0.30.0
+    "@justeattakeaway/pie-webc-core": 0.24.0
+  checksum: 3a0c0c0be981a03f4524abbb672ec47e775b00eb5cf9c4c22436328cf44eb2990b0812ab29a7de0c81cff49c702d06afebcf6de041bb11cdcc1f5b9358dd3778
   languageName: node
   linkType: hard
 
@@ -1620,12 +1635,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-divider@npm:0.13.8":
-  version: 0.13.8
-  resolution: "@justeattakeaway/pie-divider@npm:0.13.8"
+"@justeattakeaway/pie-divider@npm:0.13.9":
+  version: 0.13.9
+  resolution: "@justeattakeaway/pie-divider@npm:0.13.9"
   dependencies:
     "@justeattakeaway/pie-webc-core": 0.24.0
-  checksum: 4468b18737a801cb8a8144bdc82e2f69883a4e87ee15a597d650839044a7cc9c68cd9126cf76405c230c31d3d72d2509cb8a48a79873cc4f40c31b2672ff151c
+  checksum: c9a478e24417af7ed43af23aa4e570077f3c4fb7fb4583d112903d83b3112ef07d041181ceb70b313fe2f70b0c659faec6a01d796b7b6193d64b3d9107478d55
   languageName: node
   linkType: hard
 
@@ -1667,9 +1682,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-modal@npm:0.45.0":
-  version: 0.45.0
-  resolution: "@justeattakeaway/pie-modal@npm:0.45.0"
+"@justeattakeaway/pie-modal@npm:0.46.0":
+  version: 0.46.0
+  resolution: "@justeattakeaway/pie-modal@npm:0.46.0"
   dependencies:
     "@justeattakeaway/pie-button": 0.48.1
     "@justeattakeaway/pie-icon-button": 0.28.10
@@ -1678,7 +1693,7 @@ __metadata:
     "@justeattakeaway/pie-webc-core": 0.24.0
     body-scroll-lock: 3.1.5
     dialog-polyfill: 0.5.6
-  checksum: dbab29e6a5239effea4f7be6830e1fe068badbb0763e7951428c9023680b4b302b2971105f921799a252067b4cdbe80f33f9b5d8fcf60ff5940cf1436cb2bc9c
+  checksum: 693c134d4e17702f405307091af0a5439267342fa5f8da69f80561ea6e645ae305adc438929866c62f3d3db3a4dc6fa2631002dd342f4aa9b8dafc8486923512
   languageName: node
   linkType: hard
 
@@ -1714,6 +1729,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@justeattakeaway/pie-switch@npm:0.30.0":
+  version: 0.30.0
+  resolution: "@justeattakeaway/pie-switch@npm:0.30.0"
+  dependencies:
+    "@justeattakeaway/pie-icons-webc": 0.25.0
+    "@justeattakeaway/pie-webc-core": 0.24.0
+    "@justeattakeaway/pie-wrapper-react": 0.14.1
+    element-internals-polyfill: 1.3.11
+  checksum: 401f649f085f251be17f8fa55de7d430fb7bf62bb375633bfa8e57861f1b1800998b66e1c2cf6af01122ba85e57428dcdb99c5a485b7cb213dac26779571d04a
+  languageName: node
+  linkType: hard
+
 "@justeattakeaway/pie-tag@npm:0.9.9":
   version: 0.9.9
   resolution: "@justeattakeaway/pie-tag@npm:0.9.9"
@@ -1723,25 +1750,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-text-input@npm:0.23.3":
-  version: 0.23.3
-  resolution: "@justeattakeaway/pie-text-input@npm:0.23.3"
+"@justeattakeaway/pie-text-input@npm:0.23.4":
+  version: 0.23.4
+  resolution: "@justeattakeaway/pie-text-input@npm:0.23.4"
   dependencies:
-    "@justeattakeaway/pie-assistive-text": 0.6.1
+    "@justeattakeaway/pie-assistive-text": 0.7.0
     "@justeattakeaway/pie-webc-core": 0.24.0
     element-internals-polyfill: 1.3.11
-  checksum: 31d306d2fd0a4c065f984d3fe42d699accd084ee4679343b3b4f12e98b5ef1b0669555d7e72aaddca81c9f352feaaa46f37f3f182eed354be23f96389131aef9
+  checksum: e47f4980b0d3ede24d01b8fc171ea643ad193edef92ddfaf1dddfb9710cc600efbd374f5d6b57b38fc3fc90e0e1ba47c2544e3ee32a0af07fcbef6e59472af90
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-textarea@npm:0.6.1":
-  version: 0.6.1
-  resolution: "@justeattakeaway/pie-textarea@npm:0.6.1"
+"@justeattakeaway/pie-textarea@npm:0.8.0":
+  version: 0.8.0
+  resolution: "@justeattakeaway/pie-textarea@npm:0.8.0"
   dependencies:
     "@justeattakeaway/pie-form-label": 0.14.1
     "@justeattakeaway/pie-webc-core": 0.24.0
     lodash.throttle: 4.1.1
-  checksum: b986c978606f3133f25377fd942aeb86da6ead4e4a9909d88678aaa78f7a41972a4100be7c518fa4fef9569c22fd67d7c173d2010787da030407a3273076dafc
+  checksum: 518476f6471bb86c4afbb69cc70c60aae2b252f12a8649098f9bf62d3253b29d4bb337f9cfc76d5d9cfff3548443a75eeb1f9e19925134ba6a80ffb114b59b2f
   languageName: node
   linkType: hard
 
@@ -1766,32 +1793,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-webc@npm:0.5.19":
-  version: 0.5.19
-  resolution: "@justeattakeaway/pie-webc@npm:0.5.19"
+"@justeattakeaway/pie-webc@npm:0.5.25":
+  version: 0.5.25
+  resolution: "@justeattakeaway/pie-webc@npm:0.5.25"
   dependencies:
-    "@justeattakeaway/pie-assistive-text": 0.6.1
+    "@justeattakeaway/pie-assistive-text": 0.7.0
     "@justeattakeaway/pie-button": 0.48.1
     "@justeattakeaway/pie-card": 0.19.8
-    "@justeattakeaway/pie-checkbox": 0.12.0
-    "@justeattakeaway/pie-checkbox-group": 0.6.0
-    "@justeattakeaway/pie-chip": 0.7.2
-    "@justeattakeaway/pie-cookie-banner": 0.24.0
-    "@justeattakeaway/pie-divider": 0.13.8
+    "@justeattakeaway/pie-checkbox": 0.12.2
+    "@justeattakeaway/pie-checkbox-group": 0.6.2
+    "@justeattakeaway/pie-chip": 0.8.0
+    "@justeattakeaway/pie-cookie-banner": 0.25.1
+    "@justeattakeaway/pie-divider": 0.13.9
     "@justeattakeaway/pie-form-label": 0.14.1
     "@justeattakeaway/pie-icon-button": 0.28.10
     "@justeattakeaway/pie-link": 0.17.8
-    "@justeattakeaway/pie-modal": 0.45.0
+    "@justeattakeaway/pie-modal": 0.46.0
     "@justeattakeaway/pie-notification": 0.10.0
     "@justeattakeaway/pie-spinner": 0.6.7
-    "@justeattakeaway/pie-switch": 0.29.12
+    "@justeattakeaway/pie-switch": 0.30.0
     "@justeattakeaway/pie-tag": 0.9.9
-    "@justeattakeaway/pie-text-input": 0.23.3
-    "@justeattakeaway/pie-textarea": 0.6.1
+    "@justeattakeaway/pie-text-input": 0.23.4
+    "@justeattakeaway/pie-textarea": 0.8.0
     "@justeattakeaway/pie-toast": 0.3.1
   bin:
     add-components: src/index.js
-  checksum: ff8e3b692a225b26fc379f38f22a4d3903267e2ecf848949083ea8a252b3b48837f3e66df72cc4ddf5dd4222afa602015ad5821a752101eb8df9a86f04d119cb
+  checksum: f98f54d76cd5393562e5273d922522fc6438a473d4db86949e1bdecf17ccda9a2cf4157b4304d29eea4fa40f5d8f6bcd3df75fd84317a9e300618c6e46d24b17
   languageName: node
   linkType: hard
 
@@ -11452,10 +11479,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "nextjs-app-v13@workspace:nextjs-app-v13"
   dependencies:
-    "@justeattakeaway/pie-cookie-banner": 0.24.0
+    "@justeattakeaway/pie-cookie-banner": 0.25.0
     "@justeattakeaway/pie-css": 0.12.1
     "@justeattakeaway/pie-icons-webc": 0.25.0
-    "@justeattakeaway/pie-webc": 0.5.19
+    "@justeattakeaway/pie-webc": 0.5.25
     "@lit-labs/nextjs": 0.1.4
     "@lit/react": 1.0.2
     "@types/node": 20.9.1
@@ -11476,10 +11503,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "nextjs-app-v14@workspace:nextjs-app-v14"
   dependencies:
-    "@justeattakeaway/pie-cookie-banner": 0.24.0
+    "@justeattakeaway/pie-cookie-banner": 0.25.0
     "@justeattakeaway/pie-css": 0.12.1
     "@justeattakeaway/pie-icons-webc": 0.25.0
-    "@justeattakeaway/pie-webc": 0.5.19
+    "@justeattakeaway/pie-webc": 0.5.25
     "@lit-labs/nextjs": 0.2.0
     "@lit/react": 1.0.5
     "@types/node": 20.9.1
@@ -11809,10 +11836,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "nuxt-app@workspace:nuxt-app"
   dependencies:
-    "@justeattakeaway/pie-cookie-banner": 0.24.0
+    "@justeattakeaway/pie-cookie-banner": 0.25.0
     "@justeattakeaway/pie-css": 0.12.1
     "@justeattakeaway/pie-icons-webc": 0.25.0
-    "@justeattakeaway/pie-webc": 0.5.19
+    "@justeattakeaway/pie-webc": 0.5.25
     deepmerge: 4.3.1
     just-kebab-case: 4.2.0
     nuxt: 3.12.4
@@ -15571,10 +15598,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "vanilla-app@workspace:vanilla-app"
   dependencies:
-    "@justeattakeaway/pie-cookie-banner": 0.24.0
+    "@justeattakeaway/pie-cookie-banner": 0.25.0
     "@justeattakeaway/pie-css": 0.12.1
     "@justeattakeaway/pie-icons-webc": 0.25.0
-    "@justeattakeaway/pie-webc": 0.5.19
+    "@justeattakeaway/pie-webc": 0.5.25
     deepmerge: 4.3.1
     vite: 4.5.3
     vite-plugin-html-inject: 1.1.2


### PR DESCRIPTION
Changes mostly include refactoring several components to use classes instead of attributes for styling, but it also includes the addition of the `defaultValue` prop for pie-textarea, as well as the styling updates to fix the positioning of the resize handle.