### PR TITLE
DSW-2632: Integrate radio group pages and SSR tests

### DIFF
--- a/nextjs-app-v14/package.json
+++ b/nextjs-app-v14/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@justeattakeaway/pie-css": "0.13.1",
     "@justeattakeaway/pie-icons-webc": "1.1.0",
-    "@justeattakeaway/pie-webc": "0.0.0-snapshot-release-20241212123513",
+    "@justeattakeaway/pie-webc": "0.0.0-snapshot-release-20241212153145",
     "@lit-labs/nextjs": "0.2.0",
     "@lit/react": "1.0.6",
     "next": "14.2.18",

--- a/nextjs-app-v14/package.json
+++ b/nextjs-app-v14/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@justeattakeaway/pie-css": "0.13.1",
     "@justeattakeaway/pie-icons-webc": "1.1.0",
-    "@justeattakeaway/pie-webc": "0.5.56",
+    "@justeattakeaway/pie-webc": "0.0.0-snapshot-release-20241205123402",
     "@lit-labs/nextjs": "0.2.0",
     "@lit/react": "1.0.6",
     "next": "14.2.18",

--- a/nextjs-app-v14/package.json
+++ b/nextjs-app-v14/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@justeattakeaway/pie-css": "0.13.1",
     "@justeattakeaway/pie-icons-webc": "1.1.0",
-    "@justeattakeaway/pie-webc": "0.0.0-snapshot-release-20241205123402",
+    "@justeattakeaway/pie-webc": "0.0.0-snapshot-release-20241212123513",
     "@lit-labs/nextjs": "0.2.0",
     "@lit/react": "1.0.6",
     "next": "14.2.18",

--- a/nextjs-app-v14/package.json
+++ b/nextjs-app-v14/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@justeattakeaway/pie-css": "0.13.1",
     "@justeattakeaway/pie-icons-webc": "1.1.0",
-    "@justeattakeaway/pie-webc": "0.0.0-snapshot-release-20241212153145",
+    "@justeattakeaway/pie-webc": "0.5.59",
     "@lit-labs/nextjs": "0.2.0",
     "@lit/react": "1.0.6",
     "next": "14.2.18",

--- a/nextjs-app-v14/src/app/components/home-page.tsx
+++ b/nextjs-app-v14/src/app/components/home-page.tsx
@@ -31,6 +31,7 @@ export default function HomePage() {
       <li><PieLink onClick={() => router.push('/components/modal')} tag="button">Modal</PieLink></li>
       <li><PieLink onClick={() => router.push('/components/notification')} tag="button">Notification</PieLink></li>
       <li><PieLink onClick={() => router.push('/components/radio')} tag="button">Radio</PieLink></li>
+      <li><PieLink onClick={() => router.push('/components/radio-group')} tag="button">Radio Group</PieLink></li>
       <li><PieLink onClick={() => router.push('/components/spinner')} tag="button">Spinner</PieLink></li>
       <li><PieLink onClick={() => router.push('/components/switch')} tag="button">Switch</PieLink></li>
       <li><PieLink onClick={() => router.push('/components/tag')} tag="button">Tag</PieLink></li>

--- a/nextjs-app-v14/src/app/components/radio-group/page.tsx
+++ b/nextjs-app-v14/src/app/components/radio-group/page.tsx
@@ -1,0 +1,10 @@
+import RadioGroup from './radio-group';
+import { type Metadata } from 'next';
+
+export const metadata: Metadata = {
+    title: 'Radio Group',
+}
+
+export default function RadioGroupComponent() {
+    return <RadioGroup/>;
+}

--- a/nextjs-app-v14/src/app/components/radio-group/radio-group.tsx
+++ b/nextjs-app-v14/src/app/components/radio-group/radio-group.tsx
@@ -4,6 +4,7 @@ import NavigationLayout from "@/app/layout/navigation";
 import { PieRadio } from "@justeattakeaway/pie-webc/react/radio.js";
 import { PieRadioGroup } from "@justeattakeaway/pie-webc/react/radio-group.js";
 import { PieFormLabel } from "@justeattakeaway/pie-webc/react/form-label.js";
+import { PieButton } from "@justeattakeaway/pie-webc/react/button.js";
 
 import { useState } from "react";
 
@@ -21,8 +22,11 @@ export default function RadioGroup() {
             <PieRadioGroup name="favouriteTakeaway" onChange={handleFavouriteTakeaway as any}>
                 <PieFormLabel slot="label">Your favourite takeaway: { favouriteTakeaway }</PieFormLabel>
                 <PieRadio value="chinese">Chinese</PieRadio>
-                <PieRadio data-test-id="shawarma" value="shawarma">Shawarma</PieRadio>
+                <PieRadio value="shawarma">Shawarma</PieRadio>
+                <PieRadio value="pizza">Pizza</PieRadio>
             </PieRadioGroup>
+
+            <PieButton>Some focusable element</PieButton>
         </NavigationLayout>
     );
 }

--- a/nextjs-app-v14/src/app/components/radio-group/radio-group.tsx
+++ b/nextjs-app-v14/src/app/components/radio-group/radio-group.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import NavigationLayout from "@/app/layout/navigation";
+import { PieRadio } from "@justeattakeaway/pie-webc/react/radio.js";
+import { PieRadioGroup } from "@justeattakeaway/pie-webc/react/radio-group.js";
+import { PieFormLabel } from "@justeattakeaway/pie-webc/react/form-label.js";
+
+import { useState } from "react";
+
+export default function RadioGroup() {
+    const [favouriteTakeaway, setFavouriteTakeaway] = useState('');
+
+
+    const handleFavouriteTakeaway = (event: InputEvent) => {
+        const newFavourite = (event.target as HTMLInputElement).value;
+        setFavouriteTakeaway(newFavourite);
+    }
+
+    return (
+        <NavigationLayout title="Radio Group">
+            <PieRadioGroup name="favouriteTakeaway" onChange={handleFavouriteTakeaway as any}>
+                <PieFormLabel slot="label">Your favourite takeaway: { favouriteTakeaway }</PieFormLabel>
+                <PieRadio value="chinese">Chinese</PieRadio>
+                <PieRadio data-test-id="shawarma" value="shawarma">Shawarma</PieRadio>
+            </PieRadioGroup>
+        </NavigationLayout>
+    );
+}

--- a/nextjs-app-v14/src/app/integrations/form/form.tsx
+++ b/nextjs-app-v14/src/app/integrations/form/form.tsx
@@ -27,7 +27,6 @@ export default function Form() {
     const [contactByEmail, setContactByEmail] = useState(false);
     const [favouriteNumber, setFavouriteNumber] = useState('');
     const [favouriteNumberValidationMessage, setFavouriteNumberValidationMessage] = useState('');
-    const [radioValue, setRadioValue] = useState('');
     const [favouriteTakeaway, setFavouriteTakeaway] = useState('');
 
     const [formDataDisplay, setFormDataDisplay] = useState<string | null>(null);
@@ -77,10 +76,6 @@ export default function Form() {
     const handlePasswordInput = (event: InputEvent) => {
         setPassword((event.target as HTMLInputElement).value);
     }
-
-    const handleRadioInput = (event: InputEvent) => {
-        setRadioValue((event.target as HTMLInputElement).value);
-    };
 
     const handleApproveSettingsChange = () => {
         setApproveSettings(current => !current);

--- a/nextjs-app-v14/test/visual/nextjs.spec.js
+++ b/nextjs-app-v14/test/visual/nextjs.spec.js
@@ -20,6 +20,7 @@ describe('NextJS Aperture App', () => {
         { url: '/components/modal', name: 'Modal' },
         { url: '/components/notification', name: 'Notification' },
         { url: '/components/radio', name: 'Radio' },
+        { url: '/components/radio-group', name: 'Radio Group' },
         { url: '/components/spinner', name: 'Spinner' },
         { url: '/components/switch', name: 'Switch' },
         { url: '/components/tag', name: 'Tag' },

--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@justeattakeaway/pie-css": "0.13.1",
     "@justeattakeaway/pie-icons-webc": "1.1.0",
-    "@justeattakeaway/pie-webc": "0.0.0-snapshot-release-20241212153145",
+    "@justeattakeaway/pie-webc": "0.5.59",
     "just-kebab-case": "4.2.0",
     "nuxt-ssr-lit": "1.6.27"
   },

--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@justeattakeaway/pie-css": "0.13.1",
     "@justeattakeaway/pie-icons-webc": "1.1.0",
-    "@justeattakeaway/pie-webc": "0.0.0-snapshot-release-20241212123513",
+    "@justeattakeaway/pie-webc": "0.0.0-snapshot-release-20241212153145",
     "just-kebab-case": "4.2.0",
     "nuxt-ssr-lit": "1.6.27"
   },

--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@justeattakeaway/pie-css": "0.13.1",
     "@justeattakeaway/pie-icons-webc": "1.1.0",
-    "@justeattakeaway/pie-webc": "0.5.56",
+    "@justeattakeaway/pie-webc": "0.0.0-snapshot-release-20241205123402",
     "just-kebab-case": "4.2.0",
     "nuxt-ssr-lit": "1.6.27"
   },

--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@justeattakeaway/pie-css": "0.13.1",
     "@justeattakeaway/pie-icons-webc": "1.1.0",
-    "@justeattakeaway/pie-webc": "0.0.0-snapshot-release-20241205123402",
+    "@justeattakeaway/pie-webc": "0.0.0-snapshot-release-20241212123513",
     "just-kebab-case": "4.2.0",
     "nuxt-ssr-lit": "1.6.27"
   },

--- a/nuxt-app/pages/components/radio-group.vue
+++ b/nuxt-app/pages/components/radio-group.vue
@@ -1,32 +1,38 @@
 <template>
     <div>
-      <pie-radio-group name="favouriteTakeaway" @change="favouriteTakeaway = $event.target.value">
-          <pie-form-label>
-          Your favourite takeaway is: {{ favouriteTakeaway }}
-          </pie-form-label>
-          <pie-radio
-              value="chinese">
-              Chinese
-          </pie-radio>
-          <pie-radio
-              data-test-id="shawarma"
-              value="shawarma">
-              Shawarma
-          </pie-radio>
-      </pie-radio-group>
+        <pie-radio-group name="favouriteTakeaway" @change="favouriteTakeaway = $event.target.value">
+            <pie-form-label>
+            Your favourite takeaway is: {{ favouriteTakeaway }}
+            </pie-form-label>
+            <pie-radio
+                value="chinese">
+                Chinese
+            </pie-radio>
+            <pie-radio
+                value="shawarma">
+                Shawarma
+            </pie-radio>
+            <pie-radio
+                value="pizza">
+                Pizza
+            </pie-radio>
+        </pie-radio-group>
+        
+        <pie-button>Some focusable element</pie-button>
     </div>
-  </template>
+</template>
 
-  <script setup lang="ts">
-  import { ref } from 'vue';
-  import { definePageMeta } from '#imports';
-  import '@justeattakeaway/pie-webc/components/radio.js';
-  import '@justeattakeaway/pie-webc/components/radio-group.js';
-  import '@justeattakeaway/pie-webc/components/form-label.js';
+<script setup lang="ts">
+import { ref } from 'vue';
+import { definePageMeta } from '#imports';
+import '@justeattakeaway/pie-webc/components/radio.js';
+import '@justeattakeaway/pie-webc/components/radio-group.js';
+import '@justeattakeaway/pie-webc/components/form-label.js';
+import '@justeattakeaway/pie-webc/components/button.js';
 
-  definePageMeta({
-      title: 'Radio Group',
-  });
+definePageMeta({
+    title: 'Radio Group',
+});
 
-  const favouriteTakeaway = ref('');
-  </script>
+const favouriteTakeaway = ref('');
+</script>

--- a/nuxt-app/pages/components/radio-group.vue
+++ b/nuxt-app/pages/components/radio-group.vue
@@ -1,0 +1,32 @@
+<template>
+    <div>
+      <pie-radio-group name="favouriteTakeaway" @change="favouriteTakeaway = $event.target.value">
+          <pie-form-label>
+          Your favourite takeaway is: {{ favouriteTakeaway }}
+          </pie-form-label>
+          <pie-radio
+              value="chinese">
+              Chinese
+          </pie-radio>
+          <pie-radio
+              data-test-id="shawarma"
+              value="shawarma">
+              Shawarma
+          </pie-radio>
+      </pie-radio-group>
+    </div>
+  </template>
+
+  <script setup lang="ts">
+  import { ref } from 'vue';
+  import { definePageMeta } from '#imports';
+  import '@justeattakeaway/pie-webc/components/radio.js';
+  import '@justeattakeaway/pie-webc/components/radio-group.js';
+  import '@justeattakeaway/pie-webc/components/form-label.js';
+
+  definePageMeta({
+      title: 'Radio Group',
+  });
+
+  const favouriteTakeaway = ref('');
+  </script>

--- a/nuxt-app/pages/index.vue
+++ b/nuxt-app/pages/index.vue
@@ -21,6 +21,7 @@
       <li><pie-link href="/components/modal">Modal</pie-link></li>
       <li><pie-link href="/components/notification">Notification</pie-link></li>
       <li><pie-link href="/components/radio">Radio</pie-link></li>
+      <li><pie-link href="/components/radio-group">Radio Group</pie-link></li>
       <li><pie-link href="/components/spinner">Spinner</pie-link></li>
       <li><pie-link href="/components/switch">Switch</pie-link></li>
       <li><pie-link href="/components/tag">Tag</pie-link></li>

--- a/nuxt-app/test/visual/nuxt.spec.js
+++ b/nuxt-app/test/visual/nuxt.spec.js
@@ -20,6 +20,7 @@ describe('Nuxt Aperture App', () => {
         { url: '/components/modal', name: 'Modal' },
         { url: '/components/notification', name: 'Notification' },
         { url: '/components/radio', name: 'Radio' },
+        { url: '/components/radio-group', name: 'Radio Group' },
         { url: '/components/spinner', name: 'Spinner' },
         { url: '/components/switch', name: 'Switch' },
         { url: '/components/tag', name: 'Tag' },

--- a/test/ssr/ssr.spec.ts
+++ b/test/ssr/ssr.spec.ts
@@ -23,6 +23,8 @@ const components = [
     'link',
     'lottie-player',
     'modal',
+    'radio',
+    'radio-group',
     'spinner',
     'switch',
     'tag',

--- a/vanilla-app/components/radio-group.html
+++ b/vanilla-app/components/radio-group.html
@@ -1,0 +1,5 @@
+<load
+    src="partials/page.html"
+    title="Radio Group"
+    module="../js/radio-group.js"
+/>

--- a/vanilla-app/js/index.js
+++ b/vanilla-app/js/index.js
@@ -23,6 +23,7 @@ document.querySelector('#navigation').innerHTML = `
         <li><pie-link href="/components/modal.html">Modal</pie-link></li>
         <li><pie-link href="/components/notification.html">Notification</pie-link></li>
         <li><pie-link href="/components/radio.html">Radio</pie-link></li>
+        <li><pie-link href="/components/radio-group.html">Radio Group</pie-link></li>
         <li><pie-link href="/components/spinner.html">Spinner</pie-link></li>
         <li><pie-link href="/components/switch.html">Switch</pie-link></li>
         <li><pie-link href="/components/tag.html">Tag</pie-link></li>

--- a/vanilla-app/js/radio-group.js
+++ b/vanilla-app/js/radio-group.js
@@ -1,0 +1,27 @@
+import '@justeattakeaway/pie-webc/components/radio.js';
+import '@justeattakeaway/pie-webc/components/radio-group.js';
+import '@justeattakeaway/pie-webc/components/form-label.js';
+
+import './shared.js';
+import './utils/navigation.js';
+
+let checked = false;
+
+function handleRadioChange() {
+    const radioGroup = document.querySelector('pie-radio-group');
+    const formLabel = document.querySelector('pie-form-label');
+
+    formLabel.innerHTML = `Your favourite takeaway: ${radioGroup.value}`;
+}
+
+// Set initial HTML structure
+document.querySelector('#app').innerHTML = `
+    <pie-radio-group>
+        <pie-form-label slot="label">Your favourite takeaway:</pie-form-label>
+        <pie-radio name="favouriteTakeaway" value="chinese">Chinese</pie-radio>
+        <pie-radio name="favouriteTakeaway" data-test-id="shawarma" value="shawarma">Shawarma</pie-radio>
+    </pie-radio-group>
+`;
+
+// Add event listener to pie-radio for change events
+document.querySelector('pie-radio-group').addEventListener('change', handleRadioChange);

--- a/vanilla-app/js/radio-group.js
+++ b/vanilla-app/js/radio-group.js
@@ -1,6 +1,7 @@
 import '@justeattakeaway/pie-webc/components/radio.js';
 import '@justeattakeaway/pie-webc/components/radio-group.js';
 import '@justeattakeaway/pie-webc/components/form-label.js';
+import '@justeattakeaway/pie-webc/components/button.js';
 
 import './shared.js';
 import './utils/navigation.js';
@@ -19,8 +20,11 @@ document.querySelector('#app').innerHTML = `
     <pie-radio-group>
         <pie-form-label slot="label">Your favourite takeaway:</pie-form-label>
         <pie-radio name="favouriteTakeaway" value="chinese">Chinese</pie-radio>
-        <pie-radio name="favouriteTakeaway" data-test-id="shawarma" value="shawarma">Shawarma</pie-radio>
+        <pie-radio name="favouriteTakeaway" value="shawarma">Shawarma</pie-radio>
+        <pie-radio name="favouriteTakeaway" value="pizza">Pizza</pie-radio>
     </pie-radio-group>
+    
+    <pie-button>Some focusable element</pie-button>
 `;
 
 // Add event listener to pie-radio for change events

--- a/vanilla-app/package.json
+++ b/vanilla-app/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@justeattakeaway/pie-css": "0.13.1",
     "@justeattakeaway/pie-icons-webc": "1.1.0",
-    "@justeattakeaway/pie-webc": "0.0.0-snapshot-release-20241205123402"
+    "@justeattakeaway/pie-webc": "0.0.0-snapshot-release-20241212123513"
   },
   "installConfig": {
     "hoistingLimits": "workspaces"

--- a/vanilla-app/package.json
+++ b/vanilla-app/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@justeattakeaway/pie-css": "0.13.1",
     "@justeattakeaway/pie-icons-webc": "1.1.0",
-    "@justeattakeaway/pie-webc": "0.5.56"
+    "@justeattakeaway/pie-webc": "0.0.0-snapshot-release-20241205123402"
   },
   "installConfig": {
     "hoistingLimits": "workspaces"

--- a/vanilla-app/package.json
+++ b/vanilla-app/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@justeattakeaway/pie-css": "0.13.1",
     "@justeattakeaway/pie-icons-webc": "1.1.0",
-    "@justeattakeaway/pie-webc": "0.0.0-snapshot-release-20241212123513"
+    "@justeattakeaway/pie-webc": "0.0.0-snapshot-release-20241212153145"
   },
   "installConfig": {
     "hoistingLimits": "workspaces"

--- a/vanilla-app/package.json
+++ b/vanilla-app/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@justeattakeaway/pie-css": "0.13.1",
     "@justeattakeaway/pie-icons-webc": "1.1.0",
-    "@justeattakeaway/pie-webc": "0.0.0-snapshot-release-20241212153145"
+    "@justeattakeaway/pie-webc": "0.5.59"
   },
   "installConfig": {
     "hoistingLimits": "workspaces"

--- a/vanilla-app/test/visual/vanilla.spec.js
+++ b/vanilla-app/test/visual/vanilla.spec.js
@@ -20,6 +20,7 @@ describe('Vanilla Aperture App', () => {
         { url: '/components/modal.html', name: 'Modal' },
         { url: '/components/notification.html', name: 'Notification' },
         { url: '/components/radio.html', name: 'Radio' },
+        { url: '/components/radio-group.html', name: 'Radio Group' },
         { url: '/components/spinner.html', name: 'Spinner' },
         { url: '/components/switch.html', name: 'Switch' },
         { url: '/components/tag.html', name: 'Tag' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1268,22 +1268,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-radio-group@npm:0.3.0":
-  version: 0.3.0
-  resolution: "@justeattakeaway/pie-radio-group@npm:0.3.0"
+"@justeattakeaway/pie-radio-group@npm:0.0.0-snapshot-release-20241205123402":
+  version: 0.0.0-snapshot-release-20241205123402
+  resolution: "@justeattakeaway/pie-radio-group@npm:0.0.0-snapshot-release-20241205123402"
   dependencies:
     "@justeattakeaway/pie-assistive-text": 0.8.0
     "@justeattakeaway/pie-webc-core": 0.24.2
-  checksum: 55b49fb8982fa6dd90549f05c748455b49fb0490531cdefd556af197c36e873fc837208c934cb5c09f357d4f49654d8140deb0d52501805a461878d43429dcf0
+  checksum: 5d3d28f82023f8fc226c95157246edbd6d96d211b7539ee0222892335dff602248478bda3e75b2c7d1b32ec80f45a65be91ca3619dacd6cdf9b43b7080ba6188
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-radio@npm:0.5.0":
-  version: 0.5.0
-  resolution: "@justeattakeaway/pie-radio@npm:0.5.0"
+"@justeattakeaway/pie-radio@npm:0.0.0-snapshot-release-20241205123402":
+  version: 0.0.0-snapshot-release-20241205123402
+  resolution: "@justeattakeaway/pie-radio@npm:0.0.0-snapshot-release-20241205123402"
   dependencies:
     "@justeattakeaway/pie-webc-core": 0.24.2
-  checksum: 87cb9e3ed1cd7c0de1b1234224decd6270b5628e9412d7d03735e7513df15be435b27d5ac2230e4c00a53a761b142f30bd90c2921184784fbf4ebb296960293d
+  checksum: 4cdf61cc0831c8f92783a4416aa6903593717b78ed5d59ea75e44f682a9374d6c69dbfc769ebc35f42629dd146b70a0a5c8e3f1697973f9e084684dfc6150e1a
   languageName: node
   linkType: hard
 
@@ -1369,9 +1369,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-webc@npm:0.5.56":
-  version: 0.5.56
-  resolution: "@justeattakeaway/pie-webc@npm:0.5.56"
+"@justeattakeaway/pie-webc@npm:0.0.0-snapshot-release-20241205123402":
+  version: 0.0.0-snapshot-release-20241205123402
+  resolution: "@justeattakeaway/pie-webc@npm:0.0.0-snapshot-release-20241205123402"
   dependencies:
     "@justeattakeaway/pie-assistive-text": 0.8.0
     "@justeattakeaway/pie-button": 1.1.0
@@ -1387,8 +1387,8 @@ __metadata:
     "@justeattakeaway/pie-lottie-player": 0.0.5
     "@justeattakeaway/pie-modal": 1.0.1
     "@justeattakeaway/pie-notification": 0.12.6
-    "@justeattakeaway/pie-radio": 0.5.0
-    "@justeattakeaway/pie-radio-group": 0.3.0
+    "@justeattakeaway/pie-radio": 0.0.0-snapshot-release-20241205123402
+    "@justeattakeaway/pie-radio-group": 0.0.0-snapshot-release-20241205123402
     "@justeattakeaway/pie-spinner": 1.0.0
     "@justeattakeaway/pie-switch": 1.0.0
     "@justeattakeaway/pie-tag": 0.12.0
@@ -1398,7 +1398,7 @@ __metadata:
     "@justeattakeaway/pie-toast-provider": 0.0.0
   bin:
     add-components: src/index.js
-  checksum: e5cefb8f168f8eb323c6aa2dab61245fc95875d597b48cfabad230f56076069b12cfba935fd9fec3ae7064f7efe9c3681329a2991f0b626d3f069944afd51485
+  checksum: 864674d6d63f6d24a6f8ee57e3a3a6efbd133fbdd2ec85f405cea28c4e071cedd2223ebd0ccbf37e16379afb900d2bfec82bb5ff7ff5a80b84b8525bb9254526
   languageName: node
   linkType: hard
 
@@ -9973,7 +9973,7 @@ __metadata:
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
     "@justeattakeaway/pie-icons-webc": 1.1.0
-    "@justeattakeaway/pie-webc": 0.5.56
+    "@justeattakeaway/pie-webc": 0.0.0-snapshot-release-20241205123402
     "@lit-labs/nextjs": 0.2.0
     "@lit/react": 1.0.6
     "@types/node": 20.17.9
@@ -10290,7 +10290,7 @@ __metadata:
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
     "@justeattakeaway/pie-icons-webc": 1.1.0
-    "@justeattakeaway/pie-webc": 0.5.56
+    "@justeattakeaway/pie-webc": 0.0.0-snapshot-release-20241205123402
     deepmerge: 4.3.1
     just-kebab-case: 4.2.0
     nuxt: 3.14.1592
@@ -13840,7 +13840,7 @@ __metadata:
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
     "@justeattakeaway/pie-icons-webc": 1.1.0
-    "@justeattakeaway/pie-webc": 0.5.56
+    "@justeattakeaway/pie-webc": 0.0.0-snapshot-release-20241205123402
     deepmerge: 4.3.1
     vite: 4.5.5
     vite-plugin-html-inject: 1.1.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -1277,22 +1277,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-radio-group@npm:0.0.0-snapshot-release-20241212123513":
-  version: 0.0.0-snapshot-release-20241212123513
-  resolution: "@justeattakeaway/pie-radio-group@npm:0.0.0-snapshot-release-20241212123513"
+"@justeattakeaway/pie-radio-group@npm:0.0.0-snapshot-release-20241212153145":
+  version: 0.0.0-snapshot-release-20241212153145
+  resolution: "@justeattakeaway/pie-radio-group@npm:0.0.0-snapshot-release-20241212153145"
   dependencies:
     "@justeattakeaway/pie-assistive-text": 0.8.1
     "@justeattakeaway/pie-webc-core": 0.24.2
-  checksum: bc1ab47452a890fedcd196dc1e5fd5a408b3abd04e1ad23885fc30777e2e342f2442cb3b48f98c6b56e66f2eabd71019ecbda096bf6c667a45db8f562b789aec
+  checksum: 52d29039aedd59377e60ac1d111bf32011cb136fd5ea2acc7387cfd366afc557becf963306424a1e1b0dfde294706dba247cb1c96f25b2915212dfb55ca46a0a
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-radio@npm:0.0.0-snapshot-release-20241212123513":
-  version: 0.0.0-snapshot-release-20241212123513
-  resolution: "@justeattakeaway/pie-radio@npm:0.0.0-snapshot-release-20241212123513"
+"@justeattakeaway/pie-radio@npm:0.0.0-snapshot-release-20241212153145":
+  version: 0.0.0-snapshot-release-20241212153145
+  resolution: "@justeattakeaway/pie-radio@npm:0.0.0-snapshot-release-20241212153145"
   dependencies:
     "@justeattakeaway/pie-webc-core": 0.24.2
-  checksum: 14d452399135d373c32ef8c79e9a967ae2ac8b62fabca9a763bc514c3fd6af50d925be25ee36c408158fb44fc195155bc296e91cfc5a32e580da766787107c9a
+  checksum: 076aff469422f14e86df6348a47ec8afd787f46ef054d9b79c37c119eba1b6155bc66599be5090cd28a26f0cd2c2e87e8d3e9706229a0a43f806913164d22f6c
   languageName: node
   linkType: hard
 
@@ -1348,6 +1348,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@justeattakeaway/pie-thumbnail@npm:0.0.0":
+  version: 0.0.0
+  resolution: "@justeattakeaway/pie-thumbnail@npm:0.0.0"
+  dependencies:
+    "@justeattakeaway/pie-webc-core": 0.24.2
+  checksum: ae5c9e8e587cfa698abe2ff11f4f1fa43fd70872eddd9ac369a2625eee5551d0d06ed82eea7824b9c34877938f2c11503a1c9625a3841f077dbcd410bb96e346
+  languageName: node
+  linkType: hard
+
 "@justeattakeaway/pie-toast-provider@npm:0.0.0":
   version: 0.0.0
   resolution: "@justeattakeaway/pie-toast-provider@npm:0.0.0"
@@ -1378,9 +1387,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-webc@npm:0.0.0-snapshot-release-20241212123513":
-  version: 0.0.0-snapshot-release-20241212123513
-  resolution: "@justeattakeaway/pie-webc@npm:0.0.0-snapshot-release-20241212123513"
+"@justeattakeaway/pie-webc@npm:0.0.0-snapshot-release-20241212153145":
+  version: 0.0.0-snapshot-release-20241212153145
+  resolution: "@justeattakeaway/pie-webc@npm:0.0.0-snapshot-release-20241212153145"
   dependencies:
     "@justeattakeaway/pie-assistive-text": 0.8.1
     "@justeattakeaway/pie-button": 1.1.0
@@ -1396,18 +1405,19 @@ __metadata:
     "@justeattakeaway/pie-lottie-player": 0.0.5
     "@justeattakeaway/pie-modal": 1.0.2
     "@justeattakeaway/pie-notification": 0.12.7
-    "@justeattakeaway/pie-radio": 0.0.0-snapshot-release-20241212123513
-    "@justeattakeaway/pie-radio-group": 0.0.0-snapshot-release-20241212123513
+    "@justeattakeaway/pie-radio": 0.0.0-snapshot-release-20241212153145
+    "@justeattakeaway/pie-radio-group": 0.0.0-snapshot-release-20241212153145
     "@justeattakeaway/pie-spinner": 1.0.0
     "@justeattakeaway/pie-switch": 1.0.1
     "@justeattakeaway/pie-tag": 0.12.0
     "@justeattakeaway/pie-text-input": 0.24.6
     "@justeattakeaway/pie-textarea": 0.13.1
+    "@justeattakeaway/pie-thumbnail": 0.0.0
     "@justeattakeaway/pie-toast": 0.5.2
     "@justeattakeaway/pie-toast-provider": 0.0.0
   bin:
     add-components: src/index.js
-  checksum: 44c2daef66f64bdc7c763fe089c451b8e7846fe9bd4a2fb2cfed47d18ce4e0324009de55486f51b0ce1252093b10a56930e9d1e3e3c6c2fbbc3c0dec3719d833
+  checksum: 8e4e29759fb4c06903a416f16427c4fdf5f057d4054f9166da7091085fd6d0a4f0e7a49e5e011195a8952cb4a33f66f5a5980371d7560772f1aae2a5d7c54e8c
   languageName: node
   linkType: hard
 
@@ -9982,7 +9992,7 @@ __metadata:
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
     "@justeattakeaway/pie-icons-webc": 1.1.0
-    "@justeattakeaway/pie-webc": 0.0.0-snapshot-release-20241212123513
+    "@justeattakeaway/pie-webc": 0.0.0-snapshot-release-20241212153145
     "@lit-labs/nextjs": 0.2.0
     "@lit/react": 1.0.6
     "@types/node": 20.17.9
@@ -10299,7 +10309,7 @@ __metadata:
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
     "@justeattakeaway/pie-icons-webc": 1.1.0
-    "@justeattakeaway/pie-webc": 0.0.0-snapshot-release-20241212123513
+    "@justeattakeaway/pie-webc": 0.0.0-snapshot-release-20241212153145
     deepmerge: 4.3.1
     just-kebab-case: 4.2.0
     nuxt: 3.14.1592
@@ -13849,7 +13859,7 @@ __metadata:
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
     "@justeattakeaway/pie-icons-webc": 1.1.0
-    "@justeattakeaway/pie-webc": 0.0.0-snapshot-release-20241212123513
+    "@justeattakeaway/pie-webc": 0.0.0-snapshot-release-20241212153145
     deepmerge: 4.3.1
     vite: 4.5.5
     vite-plugin-html-inject: 1.1.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -1277,22 +1277,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-radio-group@npm:0.0.0-snapshot-release-20241212153145":
-  version: 0.0.0-snapshot-release-20241212153145
-  resolution: "@justeattakeaway/pie-radio-group@npm:0.0.0-snapshot-release-20241212153145"
+"@justeattakeaway/pie-radio-group@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@justeattakeaway/pie-radio-group@npm:0.4.0"
   dependencies:
     "@justeattakeaway/pie-assistive-text": 0.8.1
     "@justeattakeaway/pie-webc-core": 0.24.2
-  checksum: 52d29039aedd59377e60ac1d111bf32011cb136fd5ea2acc7387cfd366afc557becf963306424a1e1b0dfde294706dba247cb1c96f25b2915212dfb55ca46a0a
+  checksum: b93ac5c8d33db42d6e406817911470bba2fe2506ae1afae7cc6bf3837e98dcdfb26b1499ba01f7da6d4574e0a4151cdbc1eb2b2e22e3e3e0f02926803e73a298
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-radio@npm:0.0.0-snapshot-release-20241212153145":
-  version: 0.0.0-snapshot-release-20241212153145
-  resolution: "@justeattakeaway/pie-radio@npm:0.0.0-snapshot-release-20241212153145"
+"@justeattakeaway/pie-radio@npm:0.6.0":
+  version: 0.6.0
+  resolution: "@justeattakeaway/pie-radio@npm:0.6.0"
   dependencies:
     "@justeattakeaway/pie-webc-core": 0.24.2
-  checksum: 076aff469422f14e86df6348a47ec8afd787f46ef054d9b79c37c119eba1b6155bc66599be5090cd28a26f0cd2c2e87e8d3e9706229a0a43f806913164d22f6c
+  checksum: 08882c3e148fa7bcb9fd68ebeee709504c21a86dc52d35053e12e71d18350806aa4a3a4ddc4bc8daca5db14e1c8d952d1f4af3f8375e4b7a8b7f22692a3f37b6
   languageName: node
   linkType: hard
 
@@ -1348,12 +1348,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-thumbnail@npm:0.0.0":
-  version: 0.0.0
-  resolution: "@justeattakeaway/pie-thumbnail@npm:0.0.0"
+"@justeattakeaway/pie-thumbnail@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@justeattakeaway/pie-thumbnail@npm:0.1.0"
   dependencies:
     "@justeattakeaway/pie-webc-core": 0.24.2
-  checksum: ae5c9e8e587cfa698abe2ff11f4f1fa43fd70872eddd9ac369a2625eee5551d0d06ed82eea7824b9c34877938f2c11503a1c9625a3841f077dbcd410bb96e346
+  checksum: cb0e3d61087a51d256a03821f91106104ee53d84ff2f814c86edc9f1ef95584ff26b4cc100113e4dcb27c6564653f13f28a9534b7c878c01f56f9fcf89470c86
   languageName: node
   linkType: hard
 
@@ -1387,9 +1387,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-webc@npm:0.0.0-snapshot-release-20241212153145":
-  version: 0.0.0-snapshot-release-20241212153145
-  resolution: "@justeattakeaway/pie-webc@npm:0.0.0-snapshot-release-20241212153145"
+"@justeattakeaway/pie-webc@npm:0.5.59":
+  version: 0.5.59
+  resolution: "@justeattakeaway/pie-webc@npm:0.5.59"
   dependencies:
     "@justeattakeaway/pie-assistive-text": 0.8.1
     "@justeattakeaway/pie-button": 1.1.0
@@ -1405,19 +1405,19 @@ __metadata:
     "@justeattakeaway/pie-lottie-player": 0.0.5
     "@justeattakeaway/pie-modal": 1.0.2
     "@justeattakeaway/pie-notification": 0.12.7
-    "@justeattakeaway/pie-radio": 0.0.0-snapshot-release-20241212153145
-    "@justeattakeaway/pie-radio-group": 0.0.0-snapshot-release-20241212153145
+    "@justeattakeaway/pie-radio": 0.6.0
+    "@justeattakeaway/pie-radio-group": 0.4.0
     "@justeattakeaway/pie-spinner": 1.0.0
     "@justeattakeaway/pie-switch": 1.0.1
     "@justeattakeaway/pie-tag": 0.12.0
     "@justeattakeaway/pie-text-input": 0.24.6
     "@justeattakeaway/pie-textarea": 0.13.1
-    "@justeattakeaway/pie-thumbnail": 0.0.0
+    "@justeattakeaway/pie-thumbnail": 0.1.0
     "@justeattakeaway/pie-toast": 0.5.2
     "@justeattakeaway/pie-toast-provider": 0.0.0
   bin:
     add-components: src/index.js
-  checksum: 8e4e29759fb4c06903a416f16427c4fdf5f057d4054f9166da7091085fd6d0a4f0e7a49e5e011195a8952cb4a33f66f5a5980371d7560772f1aae2a5d7c54e8c
+  checksum: cf71c943b48c86976f51d15070a471c2be97cc1e4fb5bab8b458b48980b1691fe727b7c9f1343a74b3efd2a469e489618554841f4f436e699d43e15755f094a0
   languageName: node
   linkType: hard
 
@@ -9992,7 +9992,7 @@ __metadata:
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
     "@justeattakeaway/pie-icons-webc": 1.1.0
-    "@justeattakeaway/pie-webc": 0.0.0-snapshot-release-20241212153145
+    "@justeattakeaway/pie-webc": 0.5.59
     "@lit-labs/nextjs": 0.2.0
     "@lit/react": 1.0.6
     "@types/node": 20.17.9
@@ -10309,7 +10309,7 @@ __metadata:
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
     "@justeattakeaway/pie-icons-webc": 1.1.0
-    "@justeattakeaway/pie-webc": 0.0.0-snapshot-release-20241212153145
+    "@justeattakeaway/pie-webc": 0.5.59
     deepmerge: 4.3.1
     just-kebab-case: 4.2.0
     nuxt: 3.14.1592
@@ -13859,7 +13859,7 @@ __metadata:
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
     "@justeattakeaway/pie-icons-webc": 1.1.0
-    "@justeattakeaway/pie-webc": 0.0.0-snapshot-release-20241212153145
+    "@justeattakeaway/pie-webc": 0.5.59
     deepmerge: 4.3.1
     vite: 4.5.5
     vite-plugin-html-inject: 1.1.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -1102,13 +1102,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-assistive-text@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@justeattakeaway/pie-assistive-text@npm:0.8.0"
+"@justeattakeaway/pie-assistive-text@npm:0.8.1":
+  version: 0.8.1
+  resolution: "@justeattakeaway/pie-assistive-text@npm:0.8.1"
   dependencies:
-    "@justeattakeaway/pie-icons-webc": 1.1.0
+    "@justeattakeaway/pie-icons-webc": 1.2.0
     "@justeattakeaway/pie-webc-core": 0.24.2
-  checksum: b74657dce4dba6474e9941561dcf3e3a18686302289c78695b152bfd10fd205160183d02acc914e4716ec6247bc6f94e0be1a7c151a56e49f0d858959c9bdd2e
+  checksum: f64f92a7367cc87afd28707f539e05477aaff43c5d9da08be6fdb19bf4600a810d3f189a1cbe0bcf55bf1d4de46cb1eac0d33975b4808d54da0e4e26a15a0227
   languageName: node
   linkType: hard
 
@@ -1132,49 +1132,49 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-checkbox-group@npm:0.7.6":
-  version: 0.7.6
-  resolution: "@justeattakeaway/pie-checkbox-group@npm:0.7.6"
+"@justeattakeaway/pie-checkbox-group@npm:0.7.7":
+  version: 0.7.7
+  resolution: "@justeattakeaway/pie-checkbox-group@npm:0.7.7"
   dependencies:
-    "@justeattakeaway/pie-assistive-text": 0.8.0
+    "@justeattakeaway/pie-assistive-text": 0.8.1
     "@justeattakeaway/pie-webc-core": 0.24.2
-  checksum: ad48a95ddf6594d3617d50090faa4b7bec54c8fb92dbdae30510d4975f265043a96c05024f90fefac4f80b49714585050a048f1bf18292386b4c5a854d8b4e1c
+  checksum: 03736b6c577eb699ea17a491de61954668a80a10cef732b847e4b999e21ac73e2b44d3f0c7317c4c8675583cfba4935e9f78071a92440c0a1277cceab4de830e
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-checkbox@npm:0.13.6":
-  version: 0.13.6
-  resolution: "@justeattakeaway/pie-checkbox@npm:0.13.6"
+"@justeattakeaway/pie-checkbox@npm:0.13.7":
+  version: 0.13.7
+  resolution: "@justeattakeaway/pie-checkbox@npm:0.13.7"
   dependencies:
-    "@justeattakeaway/pie-assistive-text": 0.8.0
+    "@justeattakeaway/pie-assistive-text": 0.8.1
     "@justeattakeaway/pie-webc-core": 0.24.2
-  checksum: 1246a72d546e9ce2bcf65186cc55f33302f514c5c5c829ba0b138396e3224f468cee7dd5926c54fa68b54600b1f80e0a953278331b5a12ffe92ec9f9c547ee53
+  checksum: 24994cf3bc3276058d26e822eaa29633e51687c63b10157818509ac03af1687ad70351498c9bdf84a821e4bf960cb5a10864575735b1543bbf7b93f728f923ae
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-chip@npm:0.9.3":
-  version: 0.9.3
-  resolution: "@justeattakeaway/pie-chip@npm:0.9.3"
+"@justeattakeaway/pie-chip@npm:0.9.4":
+  version: 0.9.4
+  resolution: "@justeattakeaway/pie-chip@npm:0.9.4"
   dependencies:
-    "@justeattakeaway/pie-icons-webc": 1.1.0
+    "@justeattakeaway/pie-icons-webc": 1.2.0
     "@justeattakeaway/pie-spinner": 1.0.0
     "@justeattakeaway/pie-webc-core": 0.24.2
-  checksum: 40d1fdbbe32f8cd00f7666bf1d51484401994d287455003691270356ed840bcdd53fd71cf948abd236607c19234dfc46c069646c99f1c15864f6f419e30553ce
+  checksum: 2c96e255d350349c0a3ae547d4a63463c84f1fcccbac8f6ac69baf28b73ccc18fb92c826aba078a64dd8c8d015d973c56968b8c10e42304845793bc99abd0146
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-cookie-banner@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@justeattakeaway/pie-cookie-banner@npm:1.2.1"
+"@justeattakeaway/pie-cookie-banner@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@justeattakeaway/pie-cookie-banner@npm:1.2.2"
   dependencies:
     "@justeattakeaway/pie-button": 1.1.0
     "@justeattakeaway/pie-divider": 1.0.0
-    "@justeattakeaway/pie-icon-button": 1.0.0
+    "@justeattakeaway/pie-icon-button": 1.1.0
     "@justeattakeaway/pie-link": 1.0.0
-    "@justeattakeaway/pie-modal": 1.0.1
-    "@justeattakeaway/pie-switch": 1.0.0
+    "@justeattakeaway/pie-modal": 1.0.2
+    "@justeattakeaway/pie-switch": 1.0.1
     "@justeattakeaway/pie-webc-core": 0.24.2
-  checksum: 53836658dbd37b0907229135c323216f1e377a7e6fd05a53ff173051324dea24ffee85ff6b85674a923876f40441fb9a148f4fb3f6c941cb4309a234bd67b278
+  checksum: c0e985568162f37338919f14275ac23bd787a777b819677c92a450c3de07632f1349e596ab70f05cba4510262990186f4c1fc0cb2007de6181eaaee724c17e75
   languageName: node
   linkType: hard
 
@@ -1203,14 +1203,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-icon-button@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@justeattakeaway/pie-icon-button@npm:1.0.0"
+"@justeattakeaway/pie-icon-button@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@justeattakeaway/pie-icon-button@npm:1.1.0"
   dependencies:
-    "@justeattakeaway/pie-icons-webc": 1.1.0
+    "@justeattakeaway/pie-icons-webc": 1.2.0
     "@justeattakeaway/pie-spinner": 1.0.0
     "@justeattakeaway/pie-webc-core": 0.24.2
-  checksum: 12cc22907d87218d102fd1e243c82f0ac20c437ec864c955d39585ebf6cb611fbf771a86f9fb2a5f5943b4006a35821d9f64e17387d6750adf02b9ca85bd032e
+  checksum: ad44185e20cffe6be430ab719c4ffe91ee05ce68b863cd593452cb0a1b94d693fc44836c61d4a59239902e01c425b553eea009c78afedeefd30b03a8799e1181
   languageName: node
   linkType: hard
 
@@ -1220,6 +1220,15 @@ __metadata:
   dependencies:
     "@justeattakeaway/pie-webc-core": 0.24.2
   checksum: eb9ed23cb3dcd65883bc5ee3e7cbf9798e4fd13ebb06c79165122deafa337ae0a2f4d5a1405c3984a7a8663d376520541e053bfcce7b981025e0c43c242a4a0c
+  languageName: node
+  linkType: hard
+
+"@justeattakeaway/pie-icons-webc@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@justeattakeaway/pie-icons-webc@npm:1.2.0"
+  dependencies:
+    "@justeattakeaway/pie-webc-core": 0.24.2
+  checksum: 2f1df6f36bf4c6ce75c2af6b1a7b43a29931f128df085c68f425142b2b0c08d2f5a708e14c40f0916e74f8358cf10a391d7df6d398a2952d1cbc443747376ba8
   languageName: node
   linkType: hard
 
@@ -1242,48 +1251,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-modal@npm:1.0.1":
-  version: 1.0.1
-  resolution: "@justeattakeaway/pie-modal@npm:1.0.1"
+"@justeattakeaway/pie-modal@npm:1.0.2":
+  version: 1.0.2
+  resolution: "@justeattakeaway/pie-modal@npm:1.0.2"
   dependencies:
     "@justeattakeaway/pie-button": 1.1.0
-    "@justeattakeaway/pie-icon-button": 1.0.0
-    "@justeattakeaway/pie-icons-webc": 1.1.0
+    "@justeattakeaway/pie-icon-button": 1.1.0
+    "@justeattakeaway/pie-icons-webc": 1.2.0
     "@justeattakeaway/pie-spinner": 1.0.0
     "@justeattakeaway/pie-webc-core": 0.24.2
     body-scroll-lock: 3.1.5
     dialog-polyfill: 0.5.6
-  checksum: 617326da4e4cff09bbd318738c5746586e09fd2b7d3287de718abf24d706be40074c60fb1d1a33da132fe4669d44520c777d1ea78afadc2d5b9ab9b3a4001b6f
+  checksum: 4c0a29f37d442c10683833f56af9e8728037c35c6bde527bd528ce1638e85010601a635825a44e9cfb53b025c99a2c2dd2f363a8336d858ea262658673c41770
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-notification@npm:0.12.6":
-  version: 0.12.6
-  resolution: "@justeattakeaway/pie-notification@npm:0.12.6"
+"@justeattakeaway/pie-notification@npm:0.12.7":
+  version: 0.12.7
+  resolution: "@justeattakeaway/pie-notification@npm:0.12.7"
   dependencies:
-    "@justeattakeaway/pie-icon-button": 1.0.0
-    "@justeattakeaway/pie-icons-webc": 1.1.0
+    "@justeattakeaway/pie-icon-button": 1.1.0
+    "@justeattakeaway/pie-icons-webc": 1.2.0
     "@justeattakeaway/pie-webc-core": 0.24.2
-  checksum: c16602c561761e3d32ae02bfef5e4bf371999d29992f66caa20b461722491388604229b1bcee1ecd7576b0b2a609ec2df58ea65d8be0c8eae1303e588fbc531e
+  checksum: f1d2aa0df90a76db934f8ce5a782c7c43c081c6bc5d558fcd65d72d1fadb71aaf847269df02f1871413432544ee3f9f02c22b9b2642d88b43b234e90eabf6473
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-radio-group@npm:0.0.0-snapshot-release-20241205123402":
-  version: 0.0.0-snapshot-release-20241205123402
-  resolution: "@justeattakeaway/pie-radio-group@npm:0.0.0-snapshot-release-20241205123402"
+"@justeattakeaway/pie-radio-group@npm:0.0.0-snapshot-release-20241212123513":
+  version: 0.0.0-snapshot-release-20241212123513
+  resolution: "@justeattakeaway/pie-radio-group@npm:0.0.0-snapshot-release-20241212123513"
   dependencies:
-    "@justeattakeaway/pie-assistive-text": 0.8.0
+    "@justeattakeaway/pie-assistive-text": 0.8.1
     "@justeattakeaway/pie-webc-core": 0.24.2
-  checksum: 5d3d28f82023f8fc226c95157246edbd6d96d211b7539ee0222892335dff602248478bda3e75b2c7d1b32ec80f45a65be91ca3619dacd6cdf9b43b7080ba6188
+  checksum: bc1ab47452a890fedcd196dc1e5fd5a408b3abd04e1ad23885fc30777e2e342f2442cb3b48f98c6b56e66f2eabd71019ecbda096bf6c667a45db8f562b789aec
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-radio@npm:0.0.0-snapshot-release-20241205123402":
-  version: 0.0.0-snapshot-release-20241205123402
-  resolution: "@justeattakeaway/pie-radio@npm:0.0.0-snapshot-release-20241205123402"
+"@justeattakeaway/pie-radio@npm:0.0.0-snapshot-release-20241212123513":
+  version: 0.0.0-snapshot-release-20241212123513
+  resolution: "@justeattakeaway/pie-radio@npm:0.0.0-snapshot-release-20241212123513"
   dependencies:
     "@justeattakeaway/pie-webc-core": 0.24.2
-  checksum: 4cdf61cc0831c8f92783a4416aa6903593717b78ed5d59ea75e44f682a9374d6c69dbfc769ebc35f42629dd146b70a0a5c8e3f1697973f9e084684dfc6150e1a
+  checksum: 14d452399135d373c32ef8c79e9a967ae2ac8b62fabca9a763bc514c3fd6af50d925be25ee36c408158fb44fc195155bc296e91cfc5a32e580da766787107c9a
   languageName: node
   linkType: hard
 
@@ -1296,15 +1305,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-switch@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@justeattakeaway/pie-switch@npm:1.0.0"
+"@justeattakeaway/pie-switch@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@justeattakeaway/pie-switch@npm:1.0.1"
   dependencies:
-    "@justeattakeaway/pie-icons-webc": 1.1.0
+    "@justeattakeaway/pie-icons-webc": 1.2.0
     "@justeattakeaway/pie-webc-core": 0.24.2
     "@justeattakeaway/pie-wrapper-react": 0.14.2
     element-internals-polyfill: 1.3.11
-  checksum: 65b22aefcc77932362eecfc72ce90583de3a0ddffd730ee5635d98c7261ae1e0583d7cba1cf57b5e638684621f730ec034dc3b400ba10e44a51cc0e4eba76166
+  checksum: 9856fec48caa3a207f7ae3080c0d7053369bc111b75aaf32167bf03db9862d6fd213b687908272e8ea02eb302f3af9753e44ae40380882fda86a29a63241f2ac
   languageName: node
   linkType: hard
 
@@ -1317,25 +1326,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-text-input@npm:0.24.5":
-  version: 0.24.5
-  resolution: "@justeattakeaway/pie-text-input@npm:0.24.5"
+"@justeattakeaway/pie-text-input@npm:0.24.6":
+  version: 0.24.6
+  resolution: "@justeattakeaway/pie-text-input@npm:0.24.6"
   dependencies:
-    "@justeattakeaway/pie-assistive-text": 0.8.0
+    "@justeattakeaway/pie-assistive-text": 0.8.1
     "@justeattakeaway/pie-webc-core": 0.24.2
     element-internals-polyfill: 1.3.11
-  checksum: 4145de25bcdf2c6e1f98c8051c58dcce0e35d7ea5a0198e490b1ff68993e649e696519a8a8151684ab407cd57115d5c2fccde70efe3b040e35967812854cbae3
+  checksum: 2850e74bdb82ef80986e90514b7e5f3b41699aa5d6b3b1e87d003017a57aa2cdd7d724b2c9da6c513f0d212e001d3672179a3c21a2bfaa6ac6a434ca03d8d839
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-textarea@npm:0.13.0":
-  version: 0.13.0
-  resolution: "@justeattakeaway/pie-textarea@npm:0.13.0"
+"@justeattakeaway/pie-textarea@npm:0.13.1":
+  version: 0.13.1
+  resolution: "@justeattakeaway/pie-textarea@npm:0.13.1"
   dependencies:
-    "@justeattakeaway/pie-assistive-text": 0.8.0
+    "@justeattakeaway/pie-assistive-text": 0.8.1
     "@justeattakeaway/pie-webc-core": 0.24.2
     lodash.throttle: 4.1.1
-  checksum: a89e6602efc1219057e694d57904baf4b36d36c148ccd5a3720721335b4dad295382c3c4721db9a994f0ac79474f79217f629c319f5850db64a4e8b390e4fb10
+  checksum: 7bcfaf1a1bbcf9615542b4312048469f827a90b435b764294c0e9a09b2f671738d3aa3f73543c055de03a5ff6b4d4eb78a402c47f78b368718592ec14aee39f5
   languageName: node
   linkType: hard
 
@@ -1348,15 +1357,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-toast@npm:0.5.1":
-  version: 0.5.1
-  resolution: "@justeattakeaway/pie-toast@npm:0.5.1"
+"@justeattakeaway/pie-toast@npm:0.5.2":
+  version: 0.5.2
+  resolution: "@justeattakeaway/pie-toast@npm:0.5.2"
   dependencies:
     "@justeattakeaway/pie-button": 1.1.0
-    "@justeattakeaway/pie-icon-button": 1.0.0
-    "@justeattakeaway/pie-icons-webc": 1.1.0
+    "@justeattakeaway/pie-icon-button": 1.1.0
+    "@justeattakeaway/pie-icons-webc": 1.2.0
     "@justeattakeaway/pie-webc-core": 0.24.2
-  checksum: 13ad3df0224940acf5766bdb5e64781624229ba81a274dd1aed8484f11c5e242402c2e28c8799a0dd666af7407f864c57a9ba2a4bd25d8f528f428e87fbad83f
+  checksum: f9690f8bcb044e41adc155cf7c4bce6f0ec0ec10aa65979d67427013d69ff7266962970ef85b5bddd8521f1225dfde018bf34eb17707530aeaf85eabfe7ba576
   languageName: node
   linkType: hard
 
@@ -1369,36 +1378,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@justeattakeaway/pie-webc@npm:0.0.0-snapshot-release-20241205123402":
-  version: 0.0.0-snapshot-release-20241205123402
-  resolution: "@justeattakeaway/pie-webc@npm:0.0.0-snapshot-release-20241205123402"
+"@justeattakeaway/pie-webc@npm:0.0.0-snapshot-release-20241212123513":
+  version: 0.0.0-snapshot-release-20241212123513
+  resolution: "@justeattakeaway/pie-webc@npm:0.0.0-snapshot-release-20241212123513"
   dependencies:
-    "@justeattakeaway/pie-assistive-text": 0.8.0
+    "@justeattakeaway/pie-assistive-text": 0.8.1
     "@justeattakeaway/pie-button": 1.1.0
     "@justeattakeaway/pie-card": 0.21.3
-    "@justeattakeaway/pie-checkbox": 0.13.6
-    "@justeattakeaway/pie-checkbox-group": 0.7.6
-    "@justeattakeaway/pie-chip": 0.9.3
-    "@justeattakeaway/pie-cookie-banner": 1.2.1
+    "@justeattakeaway/pie-checkbox": 0.13.7
+    "@justeattakeaway/pie-checkbox-group": 0.7.7
+    "@justeattakeaway/pie-chip": 0.9.4
+    "@justeattakeaway/pie-cookie-banner": 1.2.2
     "@justeattakeaway/pie-divider": 1.0.0
     "@justeattakeaway/pie-form-label": 0.14.4
-    "@justeattakeaway/pie-icon-button": 1.0.0
+    "@justeattakeaway/pie-icon-button": 1.1.0
     "@justeattakeaway/pie-link": 1.0.0
     "@justeattakeaway/pie-lottie-player": 0.0.5
-    "@justeattakeaway/pie-modal": 1.0.1
-    "@justeattakeaway/pie-notification": 0.12.6
-    "@justeattakeaway/pie-radio": 0.0.0-snapshot-release-20241205123402
-    "@justeattakeaway/pie-radio-group": 0.0.0-snapshot-release-20241205123402
+    "@justeattakeaway/pie-modal": 1.0.2
+    "@justeattakeaway/pie-notification": 0.12.7
+    "@justeattakeaway/pie-radio": 0.0.0-snapshot-release-20241212123513
+    "@justeattakeaway/pie-radio-group": 0.0.0-snapshot-release-20241212123513
     "@justeattakeaway/pie-spinner": 1.0.0
-    "@justeattakeaway/pie-switch": 1.0.0
+    "@justeattakeaway/pie-switch": 1.0.1
     "@justeattakeaway/pie-tag": 0.12.0
-    "@justeattakeaway/pie-text-input": 0.24.5
-    "@justeattakeaway/pie-textarea": 0.13.0
-    "@justeattakeaway/pie-toast": 0.5.1
+    "@justeattakeaway/pie-text-input": 0.24.6
+    "@justeattakeaway/pie-textarea": 0.13.1
+    "@justeattakeaway/pie-toast": 0.5.2
     "@justeattakeaway/pie-toast-provider": 0.0.0
   bin:
     add-components: src/index.js
-  checksum: 864674d6d63f6d24a6f8ee57e3a3a6efbd133fbdd2ec85f405cea28c4e071cedd2223ebd0ccbf37e16379afb900d2bfec82bb5ff7ff5a80b84b8525bb9254526
+  checksum: 44c2daef66f64bdc7c763fe089c451b8e7846fe9bd4a2fb2cfed47d18ce4e0324009de55486f51b0ce1252093b10a56930e9d1e3e3c6c2fbbc3c0dec3719d833
   languageName: node
   linkType: hard
 
@@ -9973,7 +9982,7 @@ __metadata:
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
     "@justeattakeaway/pie-icons-webc": 1.1.0
-    "@justeattakeaway/pie-webc": 0.0.0-snapshot-release-20241205123402
+    "@justeattakeaway/pie-webc": 0.0.0-snapshot-release-20241212123513
     "@lit-labs/nextjs": 0.2.0
     "@lit/react": 1.0.6
     "@types/node": 20.17.9
@@ -10290,7 +10299,7 @@ __metadata:
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
     "@justeattakeaway/pie-icons-webc": 1.1.0
-    "@justeattakeaway/pie-webc": 0.0.0-snapshot-release-20241205123402
+    "@justeattakeaway/pie-webc": 0.0.0-snapshot-release-20241212123513
     deepmerge: 4.3.1
     just-kebab-case: 4.2.0
     nuxt: 3.14.1592
@@ -13840,7 +13849,7 @@ __metadata:
   dependencies:
     "@justeattakeaway/pie-css": 0.13.1
     "@justeattakeaway/pie-icons-webc": 1.1.0
-    "@justeattakeaway/pie-webc": 0.0.0-snapshot-release-20241205123402
+    "@justeattakeaway/pie-webc": 0.0.0-snapshot-release-20241212123513
     deepmerge: 4.3.1
     vite: 4.5.5
     vite-plugin-html-inject: 1.1.2


### PR DESCRIPTION
- Add the radio group page to each app
- Add both the radio and radio group to the SSR tests
- This version of the radio group enables keyboard navigation as introduced in [this PR](https://github.com/justeattakeaway/pie/pull/2108)