### PR TITLE
fix(pie-aperture): DSW-3311 fix upgrade-pie-packages script

### DIFF
--- a/nextjs-app-v14/package.json
+++ b/nextjs-app-v14/package.json
@@ -11,7 +11,7 @@
     "test:ssr": "APP_NAME=nextjs-app-v14 playwright test -c ../playwright.config.ts --project=ssr",
     "test:system": "APP_NAME=nextjs-app-v14 playwright test -c ../playwright.config.ts --project=system",
     "test:visual": "PERCY_TOKEN=${PERCY_TOKEN_PIE_APERTURE_NEXT_14} npx percy exec -- wdio run ./wdio.conf.js",
-    "upgrade-pie-packages": "npx npm-check-updates \"@justeattakeaway/pie-*\" -u"
+    "upgrade-pie-packages": "yarn npm-check-updates \"@justeattakeaway/pie-*\" -u"
   },
   "dependencies": {
     "@justeattakeaway/pie-css": "0.18.0",
@@ -31,6 +31,7 @@
     "deepmerge": "4.3.1",
     "eslint": "8.57.1",
     "eslint-config-next": "13.5.7",
+    "npm-check-updates": "18.0.2",
     "typescript": "5.7.2"
   },
   "installConfig": {

--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -11,10 +11,11 @@
     "test:ssr": "APP_NAME=nuxt-app npx playwright test -c ../playwright.config.ts --project=ssr",
     "test:system": "APP_NAME=nuxt-app npx playwright test -c ../playwright.config.ts --project=system",
     "test:visual": "PERCY_TOKEN=${PERCY_TOKEN_PIE_APERTURE_NUXT} npx percy exec -- wdio run ./wdio.conf.js",
-    "upgrade-pie-packages": "npx npm-check-updates \"@justeattakeaway/pie-*\" -u"
+    "upgrade-pie-packages": "yarn npm-check-updates \"@justeattakeaway/pie-*\" -u"
   },
   "devDependencies": {
     "deepmerge": "4.3.1",
+    "npm-check-updates": "18.0.2",
     "nuxt": "3.14.1592",
     "sass": "1.81.0"
   },

--- a/vanilla-app/package.json
+++ b/vanilla-app/package.json
@@ -10,10 +10,11 @@
     "preview": "vite preview",
     "test:system": "APP_NAME=vanilla-app npx playwright test --config=../playwright.config.ts --project=system",
     "test:visual": "PERCY_TOKEN=${PERCY_TOKEN_PIE_APERTURE_VANILLA} npx percy exec -- wdio run ./wdio.conf.js",
-    "upgrade-pie-packages": "npx npm-check-updates \"@justeattakeaway/pie-*\" -u"
+    "upgrade-pie-packages": "yarn npm-check-updates \"@justeattakeaway/pie-*\" -u"
   },
   "devDependencies": {
     "deepmerge": "4.3.1",
+    "npm-check-updates": "18.0.2",
     "vite": "4.5.5",
     "vite-plugin-html-inject": "1.1.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10385,6 +10385,7 @@ __metadata:
     eslint: 8.57.1
     eslint-config-next: 13.5.7
     next: 14.2.18
+    npm-check-updates: 18.0.2
     react: 18.3.1
     react-dom: 18.3.1
     sass: 1.81.0
@@ -10635,6 +10636,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npm-check-updates@npm:18.0.2":
+  version: 18.0.2
+  resolution: "npm-check-updates@npm:18.0.2"
+  bin:
+    ncu: build/cli.js
+    npm-check-updates: build/cli.js
+  checksum: b927d499cbb2f731166de301d338a7fc982ae28934c2aa4ed1c6e5df3616d49e57633bd70bc2e3f5b957adfeaee84c3ac629363b4bdb55491699cd63849b80c6
+  languageName: node
+  linkType: hard
+
 "npm-run-path@npm:^4.0.1":
   version: 4.0.1
   resolution: "npm-run-path@npm:4.0.1"
@@ -10695,6 +10706,7 @@ __metadata:
     "@justeattakeaway/pie-webc": 0.7.10
     deepmerge: 4.3.1
     just-kebab-case: 4.2.0
+    npm-check-updates: 18.0.2
     nuxt: 3.14.1592
     nuxt-ssr-lit: 1.6.27
     sass: 1.81.0
@@ -14526,6 +14538,7 @@ __metadata:
     "@justeattakeaway/pie-icons-webc": 1.13.0
     "@justeattakeaway/pie-webc": 0.7.10
     deepmerge: 4.3.1
+    npm-check-updates: 18.0.2
     vite: 4.5.5
     vite-plugin-html-inject: 1.1.2
   languageName: unknown


### PR DESCRIPTION
This ensures the `upgrade-pie-packages` script can run without stopping to ask user confirmation. 

https://github.com/user-attachments/assets/b1384540-0bc1-4a5c-b086-b0aa38ce2fbf

The user confirmation doesn't work as the process is wrapped in a single Turborepo process and it runs in parallel for each app that has the `upgrade-pie-packages` script.