### PR TITLE
feat: DSW-1982 surface `/test-aperture` deployments to PIE

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,10 +65,15 @@ jobs:
         uses: actions/checkout@v3
 
       # Detect whether this PR was opened by the test-aperture workflow by
-      # looking for metadata trailers in the head commit message.
+      # looking for metadata trailers in the head commit message. Gated on
+      # the PR author being our GitHub App so regular pie-aperture PRs
+      # (human, dependabot, renovate) skip this entirely and can't regress
+      # on a GitHub API hiccup.
       - name: Check for PIE PR metadata
         id: pie-meta
-        if: github.event_name == 'pull_request' && inputs.deploy == true
+        if: |
+          github.event_name == 'pull_request' && inputs.deploy == true &&
+          github.event.pull_request.user.login == 'pie-design-system-app[bot]'
         uses: actions/github-script@v7
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -113,7 +118,7 @@ jobs:
           github-token: ${{ steps.pie-app-token.outputs.token }}
           script: |
             const pkg = process.env.PACKAGE_NAME;
-            const environment = `aperture-${pkg}-pr-${process.env.APERTURE_PR_NUMBER}`;
+            const environment = `aperture-${pkg}`;
             const environmentUrl = `https://pr${process.env.APERTURE_PR_NUMBER}-aperture-${pkg}.pie.design/`;
             const logUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,10 +65,7 @@ jobs:
         uses: actions/checkout@v3
 
       # Detect whether this PR was opened by the test-aperture workflow by
-      # looking for metadata trailers in the head commit message. Gated on
-      # the PR author being our GitHub App so regular pie-aperture PRs
-      # (human, dependabot, renovate) skip this entirely and can't regress
-      # on a GitHub API hiccup.
+      # looking for metadata trailers in the head commit message.
       - name: Check for PIE PR metadata
         id: pie-meta
         if: |
@@ -118,7 +115,7 @@ jobs:
           github-token: ${{ steps.pie-app-token.outputs.token }}
           script: |
             const pkg = process.env.PACKAGE_NAME;
-            const environment = `aperture-${pkg}`;
+            const environment = `aperture-${pkg}-pr-${process.env.APERTURE_PR_NUMBER}`;
             const environmentUrl = `https://pr${process.env.APERTURE_PR_NUMBER}-aperture-${pkg}.pie.design/`;
             const logUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,83 @@ jobs:
       # Checkout the Repo
       - name: Checkout
         uses: actions/checkout@v3
-      
+
+      # Detect whether this PR was opened by the test-aperture workflow by
+      # looking for metadata trailers in the head commit message.
+      - name: Check for PIE PR metadata
+        id: pie-meta
+        if: github.event_name == 'pull_request' && inputs.deploy == true
+        uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            const { data: commit } = await github.rest.repos.getCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: process.env.HEAD_SHA,
+            });
+            const msg = commit.commit.message || '';
+            const numMatch = msg.match(/^pie-pr-number:\s*(\d+)\s*$/m);
+            const shaMatch = msg.match(/^pie-pr-sha:\s*([a-f0-9]+)\s*$/m);
+            if (numMatch && shaMatch) {
+              core.setOutput('present', 'true');
+              core.setOutput('pie-pr-number', numMatch[1]);
+              core.setOutput('pie-pr-sha', shaMatch[1]);
+            } else {
+              core.setOutput('present', 'false');
+            }
+
+      - name: Generate GH App token for PIE
+        id: pie-app-token
+        if: steps.pie-meta.outputs.present == 'true'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: justeattakeaway
+          repositories: pie
+
+      # Create an in_progress deployment on the PIE PR so the aperture preview surfaces natively in PIE's Deployments UI
+      - name: Create in_progress PIE deployment
+        id: pie-deploy
+        if: steps.pie-meta.outputs.present == 'true'
+        uses: actions/github-script@v7
+        env:
+          PIE_PR_SHA: ${{ steps.pie-meta.outputs.pie-pr-sha }}
+          APERTURE_PR_NUMBER: ${{ github.event.number }}
+          PACKAGE_NAME: ${{ inputs.package-name }}
+        with:
+          github-token: ${{ steps.pie-app-token.outputs.token }}
+          script: |
+            const pkg = process.env.PACKAGE_NAME;
+            const environment = `aperture-${pkg}-pr-${process.env.APERTURE_PR_NUMBER}`;
+            const environmentUrl = `https://pr${process.env.APERTURE_PR_NUMBER}-aperture-${pkg}.pie.design/`;
+            const logUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const { data: deployment } = await github.rest.repos.createDeployment({
+              owner: 'justeattakeaway',
+              repo: 'pie',
+              ref: process.env.PIE_PR_SHA,
+              environment,
+              required_contexts: [],
+              auto_merge: false,
+              transient_environment: true,
+              description: `Aperture ${pkg} preview`,
+            });
+
+            await github.rest.repos.createDeploymentStatus({
+              owner: 'justeattakeaway',
+              repo: 'pie',
+              deployment_id: deployment.id,
+              state: 'in_progress',
+              environment_url: environmentUrl,
+              log_url: logUrl,
+            });
+
+            core.setOutput('deployment-id', deployment.id);
+            core.setOutput('environment-url', environmentUrl);
+
       # Configure AWS credentials using OIDC
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
@@ -237,3 +313,40 @@ jobs:
           environment-url: https://${{ env.SUB_DOMAIN }}.pie.design/
           deployment-id: ${{ steps.deploy.outputs.deployment_id }}
           state: "failure"
+
+      - name: Update PIE deployment status (success)
+        if: steps.pie-meta.outputs.present == 'true' && github.event_name == 'pull_request' && inputs.deploy && success()
+        uses: actions/github-script@v7
+        env:
+          DEPLOYMENT_ID: ${{ steps.pie-deploy.outputs.deployment-id }}
+          ENVIRONMENT_URL: ${{ steps.pie-deploy.outputs.environment-url }}
+        with:
+          github-token: ${{ steps.pie-app-token.outputs.token }}
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: 'justeattakeaway',
+              repo: 'pie',
+              deployment_id: Number(process.env.DEPLOYMENT_ID),
+              state: 'success',
+              environment_url: process.env.ENVIRONMENT_URL,
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+
+      - name: Update PIE deployment status (failure)
+        if: steps.pie-meta.outputs.present == 'true' && github.event_name == 'pull_request' && inputs.deploy && failure()
+        uses: actions/github-script@v7
+        env:
+          DEPLOYMENT_ID: ${{ steps.pie-deploy.outputs.deployment-id }}
+          ENVIRONMENT_URL: ${{ steps.pie-deploy.outputs.environment-url }}
+        with:
+          github-token: ${{ steps.pie-app-token.outputs.token }}
+          script: |
+            if (!process.env.DEPLOYMENT_ID) return;
+            await github.rest.repos.createDeploymentStatus({
+              owner: 'justeattakeaway',
+              repo: 'pie',
+              deployment_id: Number(process.env.DEPLOYMENT_ID),
+              state: 'failure',
+              environment_url: process.env.ENVIRONMENT_URL,
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });

--- a/.github/workflows/pie-trigger.yml
+++ b/.github/workflows/pie-trigger.yml
@@ -112,13 +112,18 @@ jobs:
                 : 'is already up to date';
             const shortSha = (process.env.PIE_PR_SHA || '').slice(0, 7);
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const updatedAt = `${new Intl.DateTimeFormat('en-GB', {
+              dateStyle: 'medium',
+              timeStyle: 'short',
+              timeZone: 'UTC',
+            }).format(new Date())} UTC`;
             const body = [
               MARKER,
               `🚀 Aperture PR ${verb}: ${process.env.APERTURE_PR_URL}`,
               '',
               'App deployments will appear under the **Deployments** section of this PR shortly!',
               '',
-              `<sub>Updated ${new Date().toISOString()} · PIE @ \`${shortSha}\` · [workflow run](${runUrl})</sub>`,
+              `<sub>Updated ${updatedAt} · PIE @ \`${shortSha}\` · [workflow run](${runUrl})</sub>`,
             ].join('\n');
 
             const piePrNumber = Number(process.env.PIE_PR_NUMBER);
@@ -157,11 +162,16 @@ jobs:
             const MARKER = '<!-- test-aperture:feedback -->';
             const shortSha = (process.env.PIE_PR_SHA || '').slice(0, 7) || 'unknown';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const updatedAt = `${new Intl.DateTimeFormat('en-GB', {
+              dateStyle: 'medium',
+              timeStyle: 'short',
+              timeZone: 'UTC',
+            }).format(new Date())} UTC`;
             const body = [
               MARKER,
               `❌ The aperture PR workflow failed. [View logs](${runUrl}).`,
               '',
-              `<sub>Updated ${new Date().toISOString()} · PIE @ \`${shortSha}\` · [workflow run](${runUrl})</sub>`,
+              `<sub>Updated ${updatedAt} · PIE @ \`${shortSha}\` · [workflow run](${runUrl})</sub>`,
             ].join('\n');
 
             const piePrNumber = Number(process.env.PIE_PR_NUMBER);

--- a/.github/workflows/pie-trigger.yml
+++ b/.github/workflows/pie-trigger.yml
@@ -99,33 +99,92 @@ jobs:
         env:
           APERTURE_PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
           OPERATION: ${{ steps.create-pr.outputs.pull-request-operation }}
+          PIE_PR_SHA: ${{ steps.pie-pr.outputs.sha }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
+            const MARKER = '<!-- test-aperture:feedback -->';
             const op = process.env.OPERATION;
             const verb = op === 'created'
               ? 'created'
               : op === 'updated'
                 ? 'updated'
                 : 'is already up to date';
-            const body = `🚀 Aperture PR ${verb}: ${process.env.APERTURE_PR_URL}\n\nApp deployments will appear under the **Deployments** section of this PR shortly!`;
-            await github.rest.issues.createComment({
+            const shortSha = (process.env.PIE_PR_SHA || '').slice(0, 7);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              MARKER,
+              `🚀 Aperture PR ${verb}: ${process.env.APERTURE_PR_URL}`,
+              '',
+              'App deployments will appear under the **Deployments** section of this PR shortly!',
+              '',
+              `<sub>Updated ${new Date().toISOString()} · PIE @ \`${shortSha}\` · [workflow run](${runUrl})</sub>`,
+            ].join('\n');
+
+            const piePrNumber = Number(process.env.PIE_PR_NUMBER);
+            const { data: comments } = await github.rest.issues.listComments({
               owner: 'justeattakeaway',
               repo: 'pie',
-              issue_number: Number(process.env.PIE_PR_NUMBER),
-              body,
+              issue_number: piePrNumber,
+              per_page: 100,
             });
+            const existing = comments.find((c) => (c.body || '').includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: 'justeattakeaway',
+                repo: 'pie',
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: 'justeattakeaway',
+                repo: 'pie',
+                issue_number: piePrNumber,
+                body,
+              });
+            }
 
       - name: Report failure to PIE PR
         if: failure()
         uses: actions/github-script@v7
+        env:
+          PIE_PR_SHA: ${{ steps.pie-pr.outputs.sha }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
+            const MARKER = '<!-- test-aperture:feedback -->';
+            const shortSha = (process.env.PIE_PR_SHA || '').slice(0, 7) || 'unknown';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            await github.rest.issues.createComment({
+            const body = [
+              MARKER,
+              `❌ The aperture PR workflow failed. [View logs](${runUrl}).`,
+              '',
+              `<sub>Updated ${new Date().toISOString()} · PIE @ \`${shortSha}\` · [workflow run](${runUrl})</sub>`,
+            ].join('\n');
+
+            const piePrNumber = Number(process.env.PIE_PR_NUMBER);
+            const { data: comments } = await github.rest.issues.listComments({
               owner: 'justeattakeaway',
               repo: 'pie',
-              issue_number: Number(process.env.PIE_PR_NUMBER),
-              body: `❌ The aperture PR workflow failed. [View logs](${runUrl}).`,
+              issue_number: piePrNumber,
+              per_page: 100,
             });
+            const existing = comments.find((c) => (c.body || '').includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: 'justeattakeaway',
+                repo: 'pie',
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: 'justeattakeaway',
+                repo: 'pie',
+                issue_number: piePrNumber,
+                body,
+              });
+            }

--- a/.github/workflows/pie-trigger.yml
+++ b/.github/workflows/pie-trigger.yml
@@ -3,6 +3,20 @@ name: pie-trigger
 on:
   repository_dispatch:
     types: ['pie-trigger']
+  workflow_dispatch:
+    inputs:
+      pie-branch:
+        description: 'Source PIE branch name (used for aperture branch + commit subject)'
+        required: true
+      pie-pr-number:
+        description: 'PIE PR number to comment on; its current head SHA is fetched live'
+        required: true
+      snapshot-version:
+        description: 'Snapshot version produced by PIE test-aperture (e.g. 20260422123456)'
+        required: true
+      snapshot-packages:
+        description: 'Space-separated list of @justeattakeaway/pie-* package names'
+        required: true
 
 permissions:
   contents: write
@@ -11,6 +25,13 @@ permissions:
 jobs:
   list-snapshots:
     runs-on: ubuntu-latest
+    # Coalesce payload shapes: repository_dispatch → client_payload,
+    # workflow_dispatch → inputs. Whichever fires, these are populated.
+    env:
+      PIE_BRANCH: ${{ github.event.client_payload.pie-branch || github.event.inputs.pie-branch }}
+      PIE_PR_NUMBER: ${{ github.event.client_payload.pie-pr-number || github.event.inputs.pie-pr-number }}
+      SNAPSHOT_VERSION: ${{ github.event.client_payload.snapshot-version || github.event.inputs.snapshot-version }}
+      SNAPSHOT_PACKAGES: ${{ github.event.client_payload.snapshot-packages || github.event.inputs.snapshot-packages }}
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4
@@ -29,7 +50,7 @@ jobs:
 
       # Update snapshots
       - name: Update snapshots
-        run: npx update-snapshots ${{ github.event.client_payload.snapshot-version }} ${{ github.event.client_payload.snapshot-packages }}
+        run: npx update-snapshots "$SNAPSHOT_VERSION" $SNAPSHOT_PACKAGES
 
       - name: Generate GitHub App token
         id: app-token
@@ -37,15 +58,75 @@ jobs:
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: justeattakeaway
+          repositories: |
+            pie-aperture
+            pie
 
-      # Create PR if doesn't exist
+      - name: Fetch PIE PR head SHA
+        id: pie-pr
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: 'justeattakeaway',
+              repo: 'pie',
+              pull_number: Number(process.env.PIE_PR_NUMBER),
+            });
+            core.setOutput('sha', pr.head.sha);
+
+      # Metadata (pie-pr-number, pie-pr-sha) is embedded in the commit message
+      # as trailers so build.yml can read it atomically with the push that triggers it.
       - name: Create Pull Request
+        id: create-pr
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
-          commit-message: "feat: ${{ github.event.client_payload.pie-branch }}"
-          branch: ${{ github.event.client_payload.pie-branch }}
-          title: "feat: ${{ github.event.client_payload.pie-branch }} integration"
+          commit-message: |
+            feat: ${{ env.PIE_BRANCH }}
+
+            pie-pr-number: ${{ env.PIE_PR_NUMBER }}
+            pie-pr-sha: ${{ steps.pie-pr.outputs.sha }}
+          branch: ${{ env.PIE_BRANCH }}
+          title: "feat: ${{ env.PIE_BRANCH }} integration"
           body: |
-            This PR has been automatically generated as part of the test-aperture workflow from the Pie monorepo
+            This PR has been automatically generated as part of the test-aperture workflow from the PIE monorepo.
           draft: true
+
+      - name: Comment result on PIE PR
+        if: steps.create-pr.outputs.pull-request-number
+        uses: actions/github-script@v7
+        env:
+          APERTURE_PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
+          OPERATION: ${{ steps.create-pr.outputs.pull-request-operation }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const op = process.env.OPERATION;
+            const verb = op === 'created'
+              ? 'created'
+              : op === 'updated'
+                ? 'updated'
+                : 'is already up to date';
+            const body = `🚀 Aperture PR ${verb}: ${process.env.APERTURE_PR_URL}\n\nApp deployments will appear under the **Deployments** section of this PR shortly!`;
+            await github.rest.issues.createComment({
+              owner: 'justeattakeaway',
+              repo: 'pie',
+              issue_number: Number(process.env.PIE_PR_NUMBER),
+              body,
+            });
+
+      - name: Report failure to PIE PR
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: 'justeattakeaway',
+              repo: 'pie',
+              issue_number: Number(process.env.PIE_PR_NUMBER),
+              body: `❌ The aperture PR workflow failed. [View logs](${runUrl}).`,
+            });

--- a/.github/workflows/pie-trigger.yml
+++ b/.github/workflows/pie-trigger.yml
@@ -3,21 +3,6 @@ name: pie-trigger
 on:
   repository_dispatch:
     types: ['pie-trigger']
-  # Temporary workflow dispatch to allow manual triggering to more easily test dsw-1982 since repository_dispatch events only trigger the workflow on the default branch, and we want to be able to test on a feature branch
-  workflow_dispatch:
-    inputs:
-      pie-branch:
-        description: 'Source PIE branch name (used for aperture branch + commit subject)'
-        required: true
-      pie-pr-number:
-        description: 'PIE PR number to comment on; its current head SHA is fetched live'
-        required: true
-      snapshot-version:
-        description: 'Snapshot version produced by PIE test-aperture (e.g. 20260422123456)'
-        required: true
-      snapshot-packages:
-        description: 'Space-separated list of @justeattakeaway/pie-* package names'
-        required: true
 
 permissions:
   contents: write
@@ -27,10 +12,10 @@ jobs:
   list-snapshots:
     runs-on: ubuntu-latest
     env:
-      PIE_BRANCH: ${{ github.event.client_payload.pie-branch || github.event.inputs.pie-branch }}
-      PIE_PR_NUMBER: ${{ github.event.client_payload.pie-pr-number || github.event.inputs.pie-pr-number }}
-      SNAPSHOT_VERSION: ${{ github.event.client_payload.snapshot-version || github.event.inputs.snapshot-version }}
-      SNAPSHOT_PACKAGES: ${{ github.event.client_payload.snapshot-packages || github.event.inputs.snapshot-packages }}
+      PIE_BRANCH: ${{ github.event.client_payload.pie-branch }}
+      PIE_PR_NUMBER: ${{ github.event.client_payload.pie-pr-number }}
+      SNAPSHOT_VERSION: ${{ github.event.client_payload.snapshot-version }}
+      SNAPSHOT_PACKAGES: ${{ github.event.client_payload.snapshot-packages }}
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR aims to provide feedback from Aperture > PIE whenever `/test-aperture` is run, allowing the workflow to surface deployment information directly on the PIE PR.


The screenshots below show the updated behaviour in the PIE Repo:

**New comment highlighting that deployments will be visible with a link to the Aperture PR**
<img width="1020" height="282" alt="Screenshot 2026-04-23 at 14 46 06" src="https://github.com/user-attachments/assets/fe6652fe-3be2-4392-8775-a1688e3672be" />

**Aperture deployments are now shown directly within the PIE PR (alongside PIE Docs / Storybook)**
<img width="919" height="293" alt="Screenshot 2026-04-23 at 14 46 01" src="https://github.com/user-attachments/assets/865fa97a-a278-4846-9bb4-ee3be8d91544" />

There's a few other quality-of-life things we could do to improve the experience in PIE, however i'll look to tackle these in a separate ticket.


You can see the PIE PR I tested on here - https://github.com/justeattakeaway/pie/pull/2770

