### PR TITLE
fix: DSW-000 updated waitForTitle to waitUntilPageLoad

### DIFF
--- a/nextjs-app-v14/test/visual/nextjs.spec.js
+++ b/nextjs-app-v14/test/visual/nextjs.spec.js
@@ -1,4 +1,4 @@
-const { waitForPageTitleToBe } = require('../../../webdriver-helpers/wait-helper.js');
+const { waitUntilPageLoad } = require('../../../webdriver-helpers/wait-helper.js');
 const { percyScreenshot } = require('@percy/selenium-webdriver');
 
 describe('NextJS Aperture App', () => {
@@ -44,7 +44,7 @@ describe('NextJS Aperture App', () => {
     pages.forEach((page) => {
         it(`should navigate to the ${page.name} page.`, async () => {
             await browser.url(`${page.url}?PERCY=true`);
-            await waitForPageTitleToBe(page.name);
+            await waitUntilPageLoad();
             // Some components might require extra time to mount and load its dependencies.
             // Delaying the screenshot helps to avoid false negatives in diffs.
             if (page.pauseBeforeScreenshot) await browser.pause(5000);

--- a/nextjs-app-v15/test/visual/nextjs.spec.js
+++ b/nextjs-app-v15/test/visual/nextjs.spec.js
@@ -1,4 +1,4 @@
-const { waitForPageTitleToBe } = require('../../../webdriver-helpers/wait-helper.js');
+const { waitUntilPageLoad } = require('../../../webdriver-helpers/wait-helper.js');
 const { percyScreenshot } = require('@percy/selenium-webdriver');
 
 describe('NextJS Aperture App', () => {
@@ -43,7 +43,7 @@ describe('NextJS Aperture App', () => {
     pages.forEach((page) => {
         it(`should navigate to the ${page.name} page.`, async () => {
             await browser.url(`${page.url}?PERCY=true`);
-            await waitForPageTitleToBe(page.name);
+            await waitUntilPageLoad();
             // Some components might require extra time to mount and load its dependencies.
             // Delaying the screenshot helps to avoid false negatives in diffs.
             if (page.pauseBeforeScreenshot) await browser.pause(5000);

--- a/nuxt-app/test/visual/nuxt.spec.js
+++ b/nuxt-app/test/visual/nuxt.spec.js
@@ -1,4 +1,4 @@
-const { waitForPageTitleToBe } = require('../../../webdriver-helpers/wait-helper.js');
+const { waitUntilPageLoad } = require('../../../webdriver-helpers/wait-helper.js');
 const { percyScreenshot } = require('@percy/selenium-webdriver');
 
 describe('Nuxt Aperture App', () => {
@@ -43,7 +43,7 @@ describe('Nuxt Aperture App', () => {
     pages.forEach((page) => {
         it(`should navigate to the ${page.name} page.`, async () => {
             await browser.url(`${page.url}?PERCY=true`);
-            await waitForPageTitleToBe(page.name);
+            await waitUntilPageLoad();
             // Some components might require extra time to mount and load its dependencies.
             // Delaying the screenshot helps to avoid false negatives in diffs.
             if (page.pauseBeforeScreenshot) await browser.pause(5000);

--- a/vanilla-app/test/visual/vanilla.spec.js
+++ b/vanilla-app/test/visual/vanilla.spec.js
@@ -1,4 +1,4 @@
-import { waitForPageTitleToBe } from '../../../webdriver-helpers/wait-helper.js';
+import { waitUntilPageLoad } from '../../../webdriver-helpers/wait-helper.js';
 import { percyScreenshot } from '@percy/selenium-webdriver';
 
 describe('Vanilla Aperture App', () => {
@@ -42,7 +42,7 @@ describe('Vanilla Aperture App', () => {
     pages.forEach((page) => {
         it(`should navigate to the ${page.name} page.`, async () => {
             await browser.url(`${page.url}?PERCY=true`);
-            await waitForPageTitleToBe(page.name);
+            await waitUntilPageLoad();
             // Some components might require extra time to mount and load its dependencies.
             // Delaying the screenshot helps to avoid false negatives in diffs.
             if (page.pauseBeforeScreenshot) await browser.pause(5000);

--- a/webdriver-helpers/wait-helper.js
+++ b/webdriver-helpers/wait-helper.js
@@ -8,12 +8,3 @@ exports.waitUntilPageLoad = async (timeout = null, timeoutMsg = null) => {
     );
 }
 
-exports.waitForPageTitleToBe = async (title, timeout = null, timeoutMsg = null) => {
-    await browser.waitUntil(async function () {
-        return (await browser.getTitle()).includes(title);
-    },
-    {
-        timeout: timeout ? timeout : 60 * 1000,
-        timeoutMsg: timeoutMsg ? timeoutMsg : `Could not find the page title: ${title} in ${timeout}ms`
-    });
-}


### PR DESCRIPTION
Updated: Changed `waitForTitle` to `waitUntilPageLoad`

This resolves an issue what we're seeing with Appium on the Percy end stalling on generating the title of the page.