### PR TITLE
DSW-000: update vanilla tag props

### DIFF
--- a/vanilla-app/js/tag.js
+++ b/vanilla-app/js/tag.js
@@ -18,7 +18,7 @@ document.querySelector('#app').innerHTML = `
         ${variants.map((variant) => `
             <pie-tag
                 variant="${variant}"
-                has-leading-icon>
+                hasLeadingIcon>
                 <icon-fingerprint slot="icon"></icon-fingerprint>
                 ${variant}
             </pie-tag>
@@ -27,7 +27,7 @@ document.querySelector('#app').innerHTML = `
         ${variants.map((variant) => `
             <pie-tag
                 variant="${variant}"
-                is-icon-only>
+                isIconOnly>
                 <icon-fingerprint slot="icon"></icon-fingerprint>
             </pie-tag>
         `).join('')}
@@ -48,7 +48,7 @@ document.querySelector('#app').innerHTML = `
             <pie-tag
                 variant="${variant}"
                 isStrong
-                has-leading-icon>
+                hasLeadingIcon>
                 <icon-fingerprint slot="icon"></icon-fingerprint>
                 ${variant}
             </pie-tag>
@@ -58,7 +58,7 @@ document.querySelector('#app').innerHTML = `
             <pie-tag
                 variant="${variant}"
                 isStrong
-                is-icon-only>
+                isIconOnly>
                 <icon-fingerprint slot="icon"></icon-fingerprint>
             </pie-tag>
         `).join('')}


### PR DESCRIPTION
the used kebab caseing for the props used in vanilla aren't valid, as a result, the component isn't rendering as expected 

before:
<img width="1512" height="982" alt="Screenshot 2026-07-29 at 13 55 52" src="https://github.com/user-attachments/assets/5b0194d5-897e-45ce-b2ac-66ea98d22342" />


after:
<img width="1512" height="982" alt="Screenshot 2026-07-29 at 13 55 36" src="https://github.com/user-attachments/assets/d6ba92ad-3309-4182-98a7-a80ebb9baa57" />
