### PR TITLE
feat: DSW-3889 add textarea character limit examples

### DIFF
--- a/nextjs-app-v14/src/app/components/textarea/textarea.tsx
+++ b/nextjs-app-v14/src/app/components/textarea/textarea.tsx
@@ -1,14 +1,19 @@
 'use client';
 
 import NavigationLayout from "@/app/layout/navigation";
+import { useState } from "react";
 import { PieTextarea } from '@justeattakeaway/pie-webc/react/textarea.js';
 import { PieDivider } from '@justeattakeaway/pie-webc/react/divider.js';
+import { PieFormLabel } from '@justeattakeaway/pie-webc/react/form-label.js';
 
 export default function Textarea() {
+    const maxLength = 20;
+    const [value, setValue] = useState('');
+    const count = value.length;
 
     return (
         <NavigationLayout title="Textarea">
-            <PieTextarea value="foo"/>
+            <PieTextarea value="foo" />
 
             <PieDivider />
 
@@ -16,6 +21,16 @@ export default function Textarea() {
                 value="foo"
                 resize="manual"
             />
+
+            <PieDivider />
+
+            <PieFormLabel trailing={`${count} / ${maxLength}`}>Label </PieFormLabel>
+            <PieTextarea
+                value={value}
+                maxlength={maxLength}
+                onInput={(e) => setValue((e.target as HTMLTextAreaElement).value)}
+            />
+
         </NavigationLayout>
     );
 }

--- a/nextjs-app-v14/src/app/components/textarea/textarea.tsx
+++ b/nextjs-app-v14/src/app/components/textarea/textarea.tsx
@@ -24,7 +24,7 @@ export default function Textarea() {
 
             <PieDivider />
 
-            <PieFormLabel trailing={`${count} / ${maxLength}`}>Label </PieFormLabel>
+            <PieFormLabel trailing={`${count} / ${maxLength}`}>Label</PieFormLabel>
             <PieTextarea
                 value={value}
                 maxlength={maxLength}

--- a/nextjs-app-v15/src/app/components/textarea/textarea.tsx
+++ b/nextjs-app-v15/src/app/components/textarea/textarea.tsx
@@ -1,14 +1,19 @@
 'use client';
 
 import NavigationLayout from "@/app/layout/navigation";
+import { useState } from "react";
 import { PieTextarea } from '@justeattakeaway/pie-webc/react/textarea.js';
 import { PieDivider } from '@justeattakeaway/pie-webc/react/divider.js';
+import { PieFormLabel } from '@justeattakeaway/pie-webc/react/form-label.js';
 
 export default function Textarea() {
+    const maxLength = 20
+    const [value, setValue] = useState('');
+    const count = value.length;
 
     return (
         <NavigationLayout title="Textarea">
-            <PieTextarea value="foo"/>
+            <PieTextarea value="foo" />
 
             <PieDivider />
 
@@ -16,6 +21,15 @@ export default function Textarea() {
                 value="foo"
                 resize="manual"
             />
+
+            <PieDivider />
+
+            <PieFormLabel trailing={`${count}/${maxLength}`}> Label  </PieFormLabel>
+            <PieTextarea
+                value={value}
+                maxlength={maxLength}
+                onInput={(e) => setValue((e.target as HTMLTextAreaElement).value)} />
+
         </NavigationLayout>
     );
 }

--- a/nextjs-app-v15/src/app/components/textarea/textarea.tsx
+++ b/nextjs-app-v15/src/app/components/textarea/textarea.tsx
@@ -13,22 +13,22 @@ export default function Textarea() {
 
     return (
         <NavigationLayout title="Textarea">
-            <PieTextarea value="foo" />
+            <PieTextarea value="foo"/>
 
-            <PieDivider />
+            <PieDivider/>
 
             <PieTextarea
                 value="foo"
                 resize="manual"
             />
 
-            <PieDivider />
+            <PieDivider/>
 
-            <PieFormLabel trailing={`${count}/${maxLength}`}> Label  </PieFormLabel>
+            <PieFormLabel trailing={`${count} / ${maxLength}`}>Label</PieFormLabel>
             <PieTextarea
                 value={value}
                 maxlength={maxLength}
-                onInput={(e) => setValue((e.target as HTMLTextAreaElement).value)} />
+                onInput={(e) => setValue((e.target as HTMLTextAreaElement).value)}/>
 
         </NavigationLayout>
     );

--- a/nuxt-app/pages/components/textarea.vue
+++ b/nuxt-app/pages/components/textarea.vue
@@ -1,17 +1,35 @@
 <template>
-  <div>
-    <pie-textarea value="foo"></pie-textarea>
-    <pie-divider></pie-divider>
-    <pie-textarea resize="manual" value="foo"></pie-textarea>
-  </div>
+    <div>
+        <pie-textarea value="foo"></pie-textarea>
+        <pie-divider></pie-divider>
+        <pie-textarea resize="manual" value="foo"></pie-textarea>
+        <pie-divider></pie-divider>
+        <pie-form-label :trailing="`${count} / ${maxLength}`">Label</pie-form-label>
+        <pie-textarea
+            :value="textAreaInput"
+            :maxlength="maxLength"
+            @input="handleInput"
+        ></pie-textarea>
+    </div>
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
 import { definePageMeta } from '#imports';
 import '@justeattakeaway/pie-webc/components/textarea.js';
 import '@justeattakeaway/pie-webc/components/divider.js';
+import '@justeattakeaway/pie-webc/components/form-label.js';
 
 definePageMeta({
-  title: 'Textarea',
+    title: 'Textarea',
 });
+
+const maxLength = 20;
+const textAreaInput = ref('');
+const count = ref(0);
+
+function handleInput(e: Event) {
+    textAreaInput.value = (e.target as HTMLTextAreaElement).value;
+    count.value = textAreaInput.value.length;
+}
 </script>

--- a/vanilla-app/js/textarea.js
+++ b/vanilla-app/js/textarea.js
@@ -1,10 +1,21 @@
 import '@justeattakeaway/pie-webc/components/textarea.js';
 import '@justeattakeaway/pie-webc/components/divider.js';
+import '@justeattakeaway/pie-webc/components/form-label.js';
 
 import './utils/navigation.js';
 import './shared.js';
 
+const maxLength = 20;
+
 document.querySelector('#app').innerHTML = `
     <pie-textarea value="foo"></pie-textarea>
     <pie-divider></pie-divider>
-    <pie-textarea resize="manual" value="foo"></pie-textarea>`;
+    <pie-textarea resize="manual" value="foo"></pie-textarea>
+    <pie-divider></pie-divider>
+    <pie-form-label id="counter-label" trailing="0 / ${maxLength}">Label</pie-form-label>
+    <pie-textarea id="counter-textarea" value="" maxlength="${maxLength}"></pie-textarea>`;
+
+document.getElementById('counter-textarea').addEventListener('input', (e) => {
+    const count = e.target.value.length;
+    document.getElementById('counter-label').trailing = `${count} / ${maxLength}`;
+});


### PR DESCRIPTION
Adds character limit examples to `<pie-textarea>` for all 4 apps.

AC: As `<pie-form-label>` is a sibling component, the character count should be shown using the trailing content prop on the label.